### PR TITLE
Fix offline scrobbling for servers without lucene support

### DIFF
--- a/app/src/main/java/github/daneren2005/dsub/service/DownloadFile.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/DownloadFile.java
@@ -36,6 +36,7 @@ import github.daneren2005.dsub.domain.MusicDirectory;
 import github.daneren2005.dsub.util.Constants;
 import github.daneren2005.dsub.util.SilentBackgroundTask;
 import github.daneren2005.dsub.util.FileUtil;
+import github.daneren2005.dsub.util.SongDBHandler;
 import github.daneren2005.dsub.util.Util;
 import github.daneren2005.dsub.util.CacheCleaner;
 import github.daneren2005.serverproxy.BufferFile;
@@ -171,6 +172,8 @@ public class DownloadFile implements BufferFile {
 		}
     }
     private void preDownload() {
+		SongDBHandler.getHandler(context).addSong(this);  // Add every locally available
+		// song to db so we can use their serverId for offline scrobbling
     	FileUtil.createDirectoryForParent(saveFile);
         failedDownload = false;
 		if(!partialFile.exists()) {

--- a/app/src/main/java/github/daneren2005/dsub/service/OfflineMusicService.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/OfflineMusicService.java
@@ -558,7 +558,7 @@ public class OfflineMusicService implements MusicService {
 		SharedPreferences.Editor offlineEditor = offline.edit();
 		
 		if(id.indexOf(cacheLocn) != -1) {
-			Pair<Integer, String> cachedSongId = SongDBHandler.getHandler(context).getIdFromPath(id);
+			Pair<Integer, String> cachedSongId = SongDBHandler.getHandler(context).getIdFromPath(id.replace(".complete", ""));
 			if(cachedSongId != null) {
 				offlineEditor.putString(Constants.OFFLINE_SCROBBLE_ID + scrobbles, cachedSongId.getSecond());
 				offlineEditor.remove(Constants.OFFLINE_SCROBBLE_SEARCH + scrobbles);

--- a/app/src/main/res/layout/album_list_header.xml
+++ b/app/src/main/res/layout/album_list_header.xml
@@ -22,6 +22,7 @@
 		android:id="@+id/item_checkbox"
 		android:layout_width="wrap_content"
 		android:layout_height="wrap_content"
+		android:text="@string/main.albums_per_folder"
 		android:layout_gravity="end|center_vertical"
 		android:textColor="?android:textColorPrimary"/>
 </LinearLayout>

--- a/app/src/main/res/layout/basic_count_item.xml
+++ b/app/src/main/res/layout/basic_count_item.xml
@@ -27,7 +27,7 @@
 		android:layout_marginBottom="4px"
 		android:background="@drawable/ic_number_border"
 		android:focusable="false"
-		android:gravity="right|center_vertical"
+		android:gravity="center|center_vertical"
 		android:text="99"
 		android:textAppearance="?android:attr/textAppearanceSmallPopupMenu"
 		android:textColor="?android:textColorPrimary"


### PR DESCRIPTION
Current implementation of offline scrobbling is to save all
required data to submit scrobble in local shared preferences file
and when back online, DSub sends them to server.

When in Offline mode, dsub uses pathes to local files as their identifies
as opposite to Online mode where server side identifies are utilized. 
In order to send scrobble it is required to specify server side ID
in a query.

Thus, Dsub has to match identifies of what it has scrobbled while offline 
(paths to files in file system) to server side identifies. To do so, it relies
on
1. Querying local database, which contains mapping local path to file <-> server side id.
It sounds good but we don't live in perfect world and there are couple flaws in this implementation:
a) Dsub's local database only contains information for songs that have been played in online 
mode at least once.
b) It just doesn't work since in scrobble OfflineMusicService.scrobble method id of a song comes with ".complete"
postfix and in database it's saved without this ".complete" postfix so it fails to lookup server side id.

2. Querying the server with lucene syntax search clause. Subsonic api doesn't say anything about lucene
search syntax support and not all servers have support for it (i.e. see this issue for navidrome 
https://github.com/navidrome/navidrome/issues/1466). Besides, it isn't precise in case you have multiple
songs with same artist and title (i.e. multiple editions of an album).

This commit and according PR focus on fixing problems with looking up local path to file <-> server side id.
It is achieved with removing ".complete" substring from all identifies which 
comes to OfflineMusicSerivce.scrobble. And by adding all cached songs to local db on download stage
so when DSub switches to offline mode it always has server side identifies for all media files it has
locally.
