### PR TITLE
Ressurect instrumented tests

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -82,4 +82,5 @@ dependencies {
 	implementation 'androidx.vectordrawable:vectordrawable:1.0.0'
 	androidTestImplementation "androidx.test:runner:1.5.2"
 	androidTestImplementation "androidx.test:rules:1.5.0"
+	androidTestImplementation group: 'org.jetbrains.kotlin', name: 'kotlin-stdlib', version: '1.7.10'
 }

--- a/app/src/androidTest/java/github/daneren2005/dsub/activity/SubsonicFragmentActivityTest.java
+++ b/app/src/androidTest/java/github/daneren2005/dsub/activity/SubsonicFragmentActivityTest.java
@@ -15,7 +15,7 @@ public class SubsonicFragmentActivityTest {
 	public ActivityTestRule<SubsonicFragmentActivity> activityRule = new ActivityTestRule<>(SubsonicFragmentActivity.class, true, true);
 
 	@Before
-	protected void setUp() throws Exception {
+	public void setUp() throws Exception {
 	    activity = activityRule.getActivity();
 	}
 

--- a/app/src/main/java/github/daneren2005/dsub/service/DownloadFile.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/DownloadFile.java
@@ -36,6 +36,7 @@ import github.daneren2005.dsub.domain.MusicDirectory;
 import github.daneren2005.dsub.util.Constants;
 import github.daneren2005.dsub.util.SilentBackgroundTask;
 import github.daneren2005.dsub.util.FileUtil;
+import github.daneren2005.dsub.util.SongDBHandler;
 import github.daneren2005.dsub.util.Util;
 import github.daneren2005.dsub.util.CacheCleaner;
 import github.daneren2005.serverproxy.BufferFile;
@@ -171,6 +172,8 @@ public class DownloadFile implements BufferFile {
 		}
     }
     private void preDownload() {
+		SongDBHandler.getHandler(context).addSong(this);  // Add every locally available
+		// song to db so we can use their serverId for offline scrobbling
     	FileUtil.createDirectoryForParent(saveFile);
         failedDownload = false;
 		if(!partialFile.exists()) {

--- a/app/src/main/java/github/daneren2005/dsub/service/OfflineMusicService.java
+++ b/app/src/main/java/github/daneren2005/dsub/service/OfflineMusicService.java
@@ -558,7 +558,7 @@ public class OfflineMusicService implements MusicService {
 		SharedPreferences.Editor offlineEditor = offline.edit();
 		
 		if(id.indexOf(cacheLocn) != -1) {
-			Pair<Integer, String> cachedSongId = SongDBHandler.getHandler(context).getIdFromPath(id);
+			Pair<Integer, String> cachedSongId = SongDBHandler.getHandler(context).getIdFromPath(id.replace(".complete", ""));
 			if(cachedSongId != null) {
 				offlineEditor.putString(Constants.OFFLINE_SCROBBLE_ID + scrobbles, cachedSongId.getSecond());
 				offlineEditor.remove(Constants.OFFLINE_SCROBBLE_SEARCH + scrobbles);

--- a/app/src/main/res/layout/album_list_header.xml
+++ b/app/src/main/res/layout/album_list_header.xml
@@ -22,6 +22,7 @@
 		android:id="@+id/item_checkbox"
 		android:layout_width="wrap_content"
 		android:layout_height="wrap_content"
+		android:text="@string/main.albums_per_folder"
 		android:layout_gravity="end|center_vertical"
 		android:textColor="?android:textColorPrimary"/>
 </LinearLayout>

--- a/app/src/main/res/layout/basic_count_item.xml
+++ b/app/src/main/res/layout/basic_count_item.xml
@@ -27,7 +27,7 @@
 		android:layout_marginBottom="4px"
 		android:background="@drawable/ic_number_border"
 		android:focusable="false"
-		android:gravity="right|center_vertical"
+		android:gravity="center|center_vertical"
 		android:text="99"
 		android:textAppearance="?android:attr/textAppearanceSmallPopupMenu"
 		android:textColor="?android:textColorPrimary"


### PR DESCRIPTION
Closes #7.
Basically, it wanted to have kotlin standard library. 
Also, there is a helper method createMusicSongs which is used to provide songs for tests.
This method used to return hand-crafted song entry which actually exists on subsonic test server.
But now navidrome test server is utilized in the project by default, so some tests was getting this song, 
failed to lookup it up on navidrome demo server and thus, some tests fails. 
I redone this method to pull a really present on server song, it would allow us to run tests against different subsonic servers in future.

All tests pass except testGetRecentDownloadsWithoutPlaylist. I still don't know why, have looked up changes in related to this test code, tried to rollback them and still couldn't figure out what's wrong.
The problem actually not the test's assertion, but exception is being throw inside application code:
```
java.lang.IllegalArgumentException: fromIndex(0) > toIndex(-1)
at java.util.ArrayList.subListRangeCheck(ArrayList.java:1018)
at java.util.ArrayList.subList(ArrayList.java:1008)
at github.daneren2005.dsub.service.DownloadService.getRecentDownloads(DownloadService.java:1089)
``` 

P.S. All my pull requests are based one on another, I'm doing it because it simplifies for me building app with all my changes for personal use. I guess there would be no problems if you merge my PRs in submit order. If this is gonna cause problems, let me now and we'll figure something out.