### PR TITLE
Fixes for tests after trying them on subsonic demo server

### DIFF
--- a/app/src/androidTest/java/github/daneren2005/dsub/service/DownloadServiceTest.java
+++ b/app/src/androidTest/java/github/daneren2005/dsub/service/DownloadServiceTest.java
@@ -311,7 +311,7 @@ public class DownloadServiceTest {
 					.getChildren().get(0).getId();
 
 			MusicDirectory.Entry musicEntry = service
-					.getAlbum(albumId, "", false, context, null)
+					.getMusicDirectory(albumId, "", false, context, null)
 					.getSongs()
 					.get(0);
 
@@ -325,7 +325,7 @@ public class DownloadServiceTest {
 			return musicEntries;
 
 		} catch (Exception ex) {
-			throw new AssertionError("Failed to fetch songs");
+			throw new AssertionError(ex);
 			// Throwing exactly AssertError because it will not require to add *throws Exception*
 			// to every test case where this method gets used
 		}

--- a/app/src/androidTest/java/github/daneren2005/dsub/service/DownloadServiceTest.java
+++ b/app/src/androidTest/java/github/daneren2005/dsub/service/DownloadServiceTest.java
@@ -250,7 +250,7 @@ public class DownloadServiceTest {
 				false, 0, 0);
 
 		Log.w("testPreviousWithPlayList", "Start waiting downloads");
-		Thread.sleep(5000);
+		Thread.sleep(10000);
 		Log.w("testPreviousWithPlayList", "Stop waiting downloads");
 
 		PlayerState playerState = downloadService.getPlayerState();


### PR DESCRIPTION
I tried to run instrumented tests against subsonic demo server and for some reason, subsonic server can't find an album with specified ID in getAlbum endpoint, but finds it fine with getMusicDirectory endpoint, so we will go with it, I guess. Navidrome's demo server passes successfully either with and without this change.

Also, on machine for some reason a download from subsonic demo server wasn't ending in specified 5 seconds interval, I blame my internet speed... Anyway, I bumped that interval from 5 secs to 10 secs.