### PR TITLE
Fix: DLNA functionality requires javax.servlet-api dep, regression of 1de5177

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -79,6 +79,7 @@ dependencies {
 	implementation 'org.eclipse.jetty:jetty-server:8.1.16.v20140903'
 	implementation 'org.eclipse.jetty:jetty-servlet:8.1.16.v20140903'
 	implementation 'org.eclipse.jetty:jetty-client:8.1.16.v20140903'
+	implementation 'javax.servlet:javax.servlet-api:3.1.0'
 	implementation 'androidx.vectordrawable:vectordrawable:1.0.0'
 	androidTestImplementation "androidx.test:runner:1.5.2"
 	androidTestImplementation "androidx.test:rules:1.5.0"


### PR DESCRIPTION
Closes #13