### PR TITLE
Make tapping on cover art to open playlist configurable

### DIFF
--- a/app/src/main/java/github/daneren2005/dsub/fragments/NowPlayingFragment.java
+++ b/app/src/main/java/github/daneren2005/dsub/fragments/NowPlayingFragment.java
@@ -412,8 +412,12 @@ public class NowPlayingFragment extends SubsonicFragment implements OnGestureLis
 		albumArtImageView.setOnClickListener(new View.OnClickListener() {
 			@Override
 			public void onClick(View view) {
-				if (overlayHeight == -1 || lastY < (view.getBottom() - overlayHeight)) {
-					toggleFullscreenAlbumArt();
+				if(Util.getPreferences(context).getBoolean(Constants.PREFERENCES_KEY_TAP_COVER_FOR_PLAYLIST, true)) {
+					if (overlayHeight == -1 || lastY < (view.getBottom() - overlayHeight)) {
+						toggleFullscreenAlbumArt();
+						setControlsVisible(true);
+					}
+				} else {
 					setControlsVisible(true);
 				}
 			}

--- a/app/src/main/java/github/daneren2005/dsub/util/Constants.java
+++ b/app/src/main/java/github/daneren2005/dsub/util/Constants.java
@@ -190,6 +190,7 @@ public final class Constants {
 	public static final String PREFERENCES_KEY_DLNA_CASTING_ENABLED = "dlnaCastingEnabled";
 	public static final String PREFERENCES_KEY_REWIND_INTERVAL = "rewindInterval";
 	public static final String PREFERENCES_KEY_FASTFORWARD_INTERVAL = "fastforwardInterval";
+	public static final String PREFERENCES_KEY_TAP_COVER_FOR_PLAYLIST = "tapCoverForPlaylist";
 
 	public static final String OFFLINE_SCROBBLE_COUNT = "scrobbleCount";
 	public static final String OFFLINE_SCROBBLE_ID = "scrobbleID";

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -652,5 +652,7 @@
 	<string name="settings.server_allowinsecure">Erlaube unsichere Verbindungen</string>
 	<string name="settings.server_allowinsecure_summary">Erlaube HTTP-Verbindungen und ignoriere Warnungen und Fehler bei HTTPS-Verbindungen (nicht empfohlen!)</string>
 	<string name="background_task.network_insecure_error">Die Verbindung zum Server ist unsicher. Unsichere Verbindungen sind in den Einstellungen nicht erlaubt worden.</string>
+	<string name="settings.tap_cover_for_playlist">Albumcover öffnet Wiedergabeliste</string>
+	<string name="settings.tap_cover_for_playlist_summary">Zeige die aktuelle Wiedergabeliste wenn auf das Albumcover getippt wird</string>
 
 </resources>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -694,5 +694,7 @@
 	<string name="settings.server_allowinsecure">Allow insecure connections</string>
 	<string name="settings.server_allowinsecure_summary">Allow http traffic and ignore warnings and errors with https connections (not recommended!)</string>
 	<string name="background_task.network_insecure_error">The connection to the server is insecure. Insecure connections have not been enabled in the settings.</string>
+	<string name="settings.tap_cover_for_playlist">Album art opens playlist</string>
+	<string name="settings.tap_cover_for_playlist_summary">Open the current playlist when clicking on the album art</string>
 
 </resources>

--- a/app/src/main/res/xml/settings_playback.xml
+++ b/app/src/main/res/xml/settings_playback.xml
@@ -72,6 +72,12 @@
             android:defaultValue="30"
             android:dialogLayout="@layout/seekbar_preference"
             myns:max="60"/>
+
+        <CheckBoxPreference
+            android:title="@string/settings.tap_cover_for_playlist"
+            android:summary="@string/settings.tap_cover_for_playlist_summary"
+            android:key="tapCoverForPlaylist"
+            android:defaultValue="true"/>
 	</PreferenceCategory>
 
 	<PreferenceCategory


### PR DESCRIPTION
This introduces an option to control whether the current playlist is displayed when the album cover is tapped on the Now Playing screen. This option is enabled by default, so the previous behavior is not changed. Disabling this option makes it easier to access the fading button panel at the bottom of the cover.