### PR TITLE
CI: sign apk with present in repo debug key

### DIFF
--- a/.github/workflows/ci-build.yml
+++ b/.github/workflows/ci-build.yml
@@ -13,10 +13,13 @@ jobs:
       with:
         java-version: '17'
         distribution: 'temurin'
-    - uses: android-actions/setup-android@v3
     - uses: actions/checkout@v4
     - name: Build
       run: sh gradlew --no-daemon assembleRelease
+
+    - name: Sign the apk with debug key
+      run: /usr/local/lib/android/sdk/build-tools/34.0.0/apksigner sign --ks debug.keystore --ks-pass pass:android --ks-key-alias androiddebugkey app/build/outputs/apk/floss/release/*-release.apk
+
     - uses: actions/upload-artifact@v4
       with:
         name: DSub2000 APK


### PR DESCRIPTION
Potentially closes #22 
This workflow reuses already existing in repo debug key in debug.keystore. I understand that this key can be used by anyone to sign any apk, but I don't think it should bother us. On our side this key is only going to be used for signing CI builds, so an malefactor could use this key only to replace installed from CI artifact DSUB to a malicious DSUB, I think it's unlikely somebody going to target this. Especially after we get DSub2000 to fdroid.

Additionally, this would allow for third-party forks to provide builds, compatible with ours. Thus allowing for users to switch between forks of their choice, if desired.

Also, it appears step setup-android isn't required, the flow works without it, so deleting it.