### PR TITLE
Update targetSdkVersion to 33

### DIFF
--- a/ServerProxy/build.gradle
+++ b/ServerProxy/build.gradle
@@ -25,8 +25,8 @@ android {
     namespace "github.paroj.serverproxy"
 
     defaultConfig {
-        targetSdkVersion 30
-        minSdkVersion = 24
+        targetSdkVersion 33
+        minSdkVersion 24
     }
 
     sourceSets {

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 	defaultConfig {
 		applicationId "github.paroj.dsub2000"
 		minSdkVersion 24
-		targetSdkVersion 31
+		targetSdkVersion 33
 		versionCode 209
 		versionName '5.6.0'
 		vectorDrawables.useSupportLibrary = true
@@ -74,7 +74,7 @@ dependencies {
 	implementation project(':ServerProxy')
 	implementation fileTree(include: ['*.jar'], dir: 'libs')
 	implementation 'androidx.legacy:legacy-support-v4:1.0.0'
-	implementation 'androidx.appcompat:appcompat:1.0.0'
+	implementation 'androidx.appcompat:appcompat:1.3.1'
 	implementation 'androidx.mediarouter:mediarouter:1.1.0'
 	implementation 'androidx.recyclerview:recyclerview:1.0.0'
 	implementation 'com.google.android.material:material:1.0.0'

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -6,7 +6,7 @@ android {
 	defaultConfig {
 		applicationId "github.paroj.dsub2000"
 		minSdkVersion 24
-		targetSdkVersion 30
+		targetSdkVersion 31
 		versionCode 209
 		versionName '5.6.0'
 		vectorDrawables.useSupportLibrary = true

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,6 +45,7 @@
 
 		<activity android:name="github.paroj.dsub2000.activity.SubsonicFragmentActivity"
 				  android:configChanges="keyboardHidden"
+				  android:exported="true"
 				  android:launchMode="singleTask">
 			<intent-filter>
 				<action android:name="android.intent.action.MAIN"/>
@@ -58,6 +59,7 @@
                   android:launchMode="singleTask"/>
 
         <activity android:name="github.paroj.dsub2000.activity.VoiceQueryReceiverActivity"
+				  android:exported="true"
                   android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.media.action.MEDIA_PLAY_FROM_SEARCH" />
@@ -72,6 +74,7 @@
         </activity>
 
         <activity android:name="github.paroj.dsub2000.activity.QueryReceiverActivity"
+				  android:exported="true"
                   android:launchMode="singleTask">
             <intent-filter>
                 <action android:name="android.intent.action.SEARCH"/>
@@ -82,6 +85,7 @@
 		<activity
 			android:name="github.paroj.dsub2000.activity.EditPlayActionActivity"
 			android:label="@string/tasker.start_playing"
+			android:exported="true"
 			android:icon="@drawable/launch">
 
 			<intent-filter>
@@ -102,7 +106,10 @@
 		</service>
 
 		<service android:name="org.jupnp.android.AndroidUpnpServiceImpl"/>
-		<service android:name="github.paroj.dsub2000.service.sync.AuthenticatorService">
+		<service
+			android:name="github.paroj.dsub2000.service.sync.AuthenticatorService"
+			android:exported="true">
+
 			<intent-filter>
 				<action android:name="android.accounts.AccountAuthenticator"/>
 			</intent-filter>
@@ -154,20 +161,23 @@
 		<service android:name="github.paroj.dsub2000.service.HeadphoneListenerService"
 			android:label="DSub Headphone Listener"/>
 		<receiver
-			android:name="github.paroj.dsub2000.receiver.BootReceiver">
+			android:name="github.paroj.dsub2000.receiver.BootReceiver"
+			android:exported="true">
 			<intent-filter>
 				<action
 					android:name="android.intent.action.BOOT_COMPLETED" />
 			</intent-filter>
 		</receiver>
 
-        <receiver android:name="github.paroj.dsub2000.receiver.MediaButtonIntentReceiver">
+        <receiver android:name="github.paroj.dsub2000.receiver.MediaButtonIntentReceiver"
+			android:exported="true">
         	<intent-filter>
 				<action android:name="android.intent.action.MEDIA_BUTTON" />
 			</intent-filter>
         </receiver>
 
-		<receiver android:name="github.paroj.dsub2000.receiver.A2dpIntentReceiver">
+		<receiver android:name="github.paroj.dsub2000.receiver.A2dpIntentReceiver"
+			android:exported="true">
 			<intent-filter>
 				<action android:name="android.music.playstatusrequest"/>
 			</intent-filter>
@@ -175,6 +185,7 @@
 
         <receiver
 			android:name="github.paroj.dsub2000.provider.DSubWidget4x1"
+			android:exported="true"
 			android:label="@string/widget.4x1">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
@@ -183,6 +194,7 @@
         </receiver>
 		<receiver
 			android:name="github.paroj.dsub2000.provider.DSubWidget4x2"
+			android:exported="true"
 			android:label="@string/widget.4x2">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
@@ -191,6 +203,7 @@
         </receiver>
 		<receiver
 			android:name="github.paroj.dsub2000.provider.DSubWidget4x3"
+			android:exported="true"
 			android:label="@string/widget.4x3">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
@@ -199,6 +212,7 @@
         </receiver>
 		<receiver
 			android:name="github.paroj.dsub2000.provider.DSubWidget4x4"
+			android:exported="true"
 			android:label="@string/widget.4x4">
             <intent-filter>
                 <action android:name="android.appwidget.action.APPWIDGET_UPDATE"/>
@@ -207,7 +221,8 @@
         </receiver>
 
 		<receiver
-			android:name="github.paroj.dsub2000.receiver.PlayActionReceiver">
+			android:name="github.paroj.dsub2000.receiver.PlayActionReceiver"
+			android:exported="true">
 
 			<intent-filter>
 				<action android:name="com.twofortyfouram.locale.intent.action.FIRE_SETTING" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -14,7 +14,6 @@
     <uses-permission android:name="android.permission.RECORD_AUDIO" android:maxSdkVersion="22"/>
     <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
 	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-	<uses-permission android:name="android.permission.BLUETOOTH"/>
 	<uses-permission android:name="android.permission.READ_SYNC_SETTINGS"/>
 	<uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS"/>
 	<uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -12,8 +12,9 @@
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
     <uses-permission android:name="android.permission.RECORD_AUDIO" android:maxSdkVersion="22"/>
-    <uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
-	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
+	<uses-permission android:name="android.permission.MODIFY_AUDIO_SETTINGS"/>
+	<uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" android:maxSdkVersion="32"/>
+	<uses-permission android:name="android.permission.READ_MEDIA_AUDIO" />
 	<uses-permission android:name="android.permission.READ_SYNC_SETTINGS"/>
 	<uses-permission android:name="android.permission.WRITE_SYNC_SETTINGS"/>
 	<uses-permission android:name="android.permission.AUTHENTICATE_ACCOUNTS"/>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -21,6 +21,7 @@
 	<uses-permission android:name="android.permission.CHANGE_WIFI_MULTICAST_STATE"/>
 	<uses-permission android:name="android.permission.RECEIVE_BOOT_COMPLETED"/>
 	<uses-permission android:name="android.permission.ACCESS_FINE_LOCATION"/>
+	<uses-permission android:name="android.permission.ACCESS_COARSE_LOCATION" />
 	<uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
 	<uses-feature android:name="android.hardware.touchscreen" android:required="false" />

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -7,7 +7,7 @@
 		android:label="Tests" />
 
     <uses-permission android:name="android.permission.INTERNET"/>
-    <uses-permission android:name="android.permission.READ_PHONE_STATE" android:maxSdkVersion="22"/>
+    <uses-permission android:name="android.permission.READ_PHONE_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.WAKE_LOCK"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>

--- a/app/src/main/java/github/paroj/dsub2000/activity/SubsonicActivity.java
+++ b/app/src/main/java/github/paroj/dsub2000/activity/SubsonicActivity.java
@@ -99,6 +99,8 @@ public class SubsonicActivity extends AppCompatActivity implements OnItemSelecte
 	public static final int PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE = 1;
 	public static final int PERMISSIONS_REQUEST_LOCATION = 2;
 
+	public static final int PERMISSIONS_REQUEST_READ_PHONE_STATE = 3;
+
 	private final List<Runnable> afterServiceAvailable = new ArrayList<>();
 	private boolean drawerIdle = true;
 	private boolean destroyed = false;
@@ -186,6 +188,11 @@ public class SubsonicActivity extends AppCompatActivity implements OnItemSelecte
 			ActivityCompat.requestPermissions(this, new String[]{ permission.WRITE_EXTERNAL_STORAGE }, PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE);
 		}
 
+		// To be able to stop playback during calls, we need the phone state permission.
+		if (ContextCompat.checkSelfPermission(this, permission.READ_PHONE_STATE) != PackageManager.PERMISSION_GRANTED) {
+			ActivityCompat.requestPermissions(this, new String[]{ permission.READ_PHONE_STATE }, PERMISSIONS_REQUEST_READ_PHONE_STATE);
+		}
+
 		SharedPreferences prefs = Util.getPreferences(this);
 		int instance = prefs.getInt(Constants.PREFERENCES_KEY_SERVER_INSTANCE, 1);
 		String expectedSSID = prefs.getString(Constants.PREFERENCES_KEY_SERVER_LOCAL_NETWORK_SSID + instance, "");
@@ -216,6 +223,15 @@ public class SubsonicActivity extends AppCompatActivity implements OnItemSelecte
 
 				} else {
 					Util.toast(this, R.string.permission_location_failed);
+				}
+			}
+
+			case PERMISSIONS_REQUEST_READ_PHONE_STATE: {
+				// If request is cancelled, the result arrays are empty.
+				if (grantResults.length > 0 && grantResults[0] == PackageManager.PERMISSION_GRANTED) {
+
+				} else {
+					Util.toast(this, R.string.permission_phone_state_failed);
 				}
 			}
 		}

--- a/app/src/main/java/github/paroj/dsub2000/activity/SubsonicActivity.java
+++ b/app/src/main/java/github/paroj/dsub2000/activity/SubsonicActivity.java
@@ -193,7 +193,7 @@ public class SubsonicActivity extends AppCompatActivity implements OnItemSelecte
 			String currentSSID = Util.getSSID(this);
 
 			if("<unknown ssid>".equals(currentSSID) && ActivityCompat.checkSelfPermission(this, Manifest.permission.ACCESS_FINE_LOCATION) != PackageManager.PERMISSION_GRANTED) {
-				ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.ACCESS_FINE_LOCATION}, SubsonicActivity.PERMISSIONS_REQUEST_LOCATION);
+				ActivityCompat.requestPermissions(this, new String[]{Manifest.permission.ACCESS_FINE_LOCATION, Manifest.permission.ACCESS_COARSE_LOCATION}, SubsonicActivity.PERMISSIONS_REQUEST_LOCATION);
 			}
 		}
 	}

--- a/app/src/main/java/github/paroj/dsub2000/provider/DSubWidgetProvider.java
+++ b/app/src/main/java/github/paroj/dsub2000/provider/DSubWidgetProvider.java
@@ -280,7 +280,7 @@ public class DSubWidgetProvider extends AppWidgetProvider {
 		Intent intent = new Intent(context, SubsonicFragmentActivity.class);
 		intent.putExtra(Constants.INTENT_EXTRA_NAME_DOWNLOAD, true);
 		intent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, 0);
+        PendingIntent pendingIntent = PendingIntent.getActivity(context, 0, intent, /* flags */ PendingIntent.FLAG_IMMUTABLE);
         views.setOnClickPendingIntent(R.id.appwidget_coverart, pendingIntent);
         views.setOnClickPendingIntent(R.id.appwidget_top, pendingIntent);
 
@@ -291,7 +291,7 @@ public class DSubWidgetProvider extends AppWidgetProvider {
         if (Build.VERSION.SDK_INT >= 26)
             pendingIntent = PendingIntent.getForegroundService(context, 0, intent, 0);
         else
-            pendingIntent = PendingIntent.getService(context, 0, intent, 0);
+            pendingIntent = PendingIntent.getService(context, 0, intent, /* flags */ PendingIntent.FLAG_IMMUTABLE);
         views.setOnClickPendingIntent(R.id.control_play, pendingIntent);
 
         intent = new Intent("DSub.NEXT");  // Use a unique action name to ensure a different PendingIntent to be created.
@@ -300,7 +300,7 @@ public class DSubWidgetProvider extends AppWidgetProvider {
         if (Build.VERSION.SDK_INT >= 26)
             pendingIntent = PendingIntent.getForegroundService(context, 0, intent, 0);
         else
-            pendingIntent = PendingIntent.getService(context, 0, intent, 0);
+            pendingIntent = PendingIntent.getService(context, 0, intent, /* flags */ PendingIntent.FLAG_IMMUTABLE);
         views.setOnClickPendingIntent(R.id.control_next, pendingIntent);
 
         intent = new Intent("DSub.PREVIOUS");  // Use a unique action name to ensure a different PendingIntent to be created.
@@ -309,7 +309,7 @@ public class DSubWidgetProvider extends AppWidgetProvider {
         if (Build.VERSION.SDK_INT >= 26)
             pendingIntent = PendingIntent.getForegroundService(context, 0, intent, 0);
         else
-            pendingIntent = PendingIntent.getService(context, 0, intent, 0);
+            pendingIntent = PendingIntent.getService(context, 0, intent, /* flags */ PendingIntent.FLAG_IMMUTABLE);
         views.setOnClickPendingIntent(R.id.control_previous, pendingIntent);
     }
 }

--- a/app/src/main/java/github/paroj/dsub2000/service/DownloadServiceLifecycleSupport.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/DownloadServiceLifecycleSupport.java
@@ -24,11 +24,13 @@ import java.util.List;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.concurrent.atomic.AtomicBoolean;
 
+import android.Manifest;
 import android.content.BroadcastReceiver;
 import android.content.Context;
 import android.content.Intent;
 import android.content.IntentFilter;
 import android.content.SharedPreferences;
+import android.content.pm.PackageManager;
 import android.media.RemoteControlClient;
 import android.os.Handler;
 import android.os.Looper;
@@ -51,6 +53,8 @@ import github.paroj.dsub2000.util.SongDBHandler;
 import github.paroj.dsub2000.util.Util;
 
 import static github.paroj.dsub2000.domain.PlayerState.PREPARING;
+
+import androidx.core.content.ContextCompat;
 
 /**
  * @author Sindre Mehus
@@ -158,9 +162,10 @@ public class DownloadServiceLifecycleSupport {
 		// Pause temporarily on incoming phone calls.
 		phoneStateListener = new MyPhoneStateListener();
 
-		// Android 6.0 removes requirement for android.Manifest.permission.READ_PHONE_STATE;
-		TelephonyManager telephonyManager = (TelephonyManager) downloadService.getSystemService(Context.TELEPHONY_SERVICE);
-		telephonyManager.listen(phoneStateListener, PhoneStateListener.LISTEN_CALL_STATE);
+		if (ContextCompat.checkSelfPermission(this.downloadService, Manifest.permission.READ_PHONE_STATE) == PackageManager.PERMISSION_GRANTED) {
+			TelephonyManager telephonyManager = (TelephonyManager) downloadService.getSystemService(Context.TELEPHONY_SERVICE);
+			telephonyManager.listen(phoneStateListener, PhoneStateListener.LISTEN_CALL_STATE);
+		}
 
 		// Register the handler for outside intents.
 		IntentFilter commandFilter = new IntentFilter();

--- a/app/src/main/java/github/paroj/dsub2000/util/Notifications.java
+++ b/app/src/main/java/github/paroj/dsub2000/util/Notifications.java
@@ -172,7 +172,7 @@ public final class Notifications {
 		Intent notificationIntent = new Intent(context, SubsonicFragmentActivity.class);
 		notificationIntent.putExtra(Constants.INTENT_EXTRA_NAME_DOWNLOAD, true);
 		notificationIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-		notification.contentIntent = PendingIntent.getActivity(context, 0, notificationIntent, 0);
+		notification.contentIntent = PendingIntent.getActivity(context, 0, notificationIntent, /* flags */ PendingIntent.FLAG_IMMUTABLE);
 
 		playShowing = true;
 		if(downloadForeground && downloadShowing) {
@@ -259,7 +259,7 @@ public final class Notifications {
 			intent.putExtra(Intent.EXTRA_KEY_EVENT, new KeyEvent(KeyEvent.ACTION_UP, keyCode));
 		}
 
-		return PendingIntent.getService(context, 0, intent, 0);
+		return PendingIntent.getService(context, 0, intent, /* flags */ PendingIntent.FLAG_IMMUTABLE);
 	}
 
 	private static void setupViews(RemoteViews rv, Context context, MusicDirectory.Entry song, boolean expanded, boolean playing, boolean remote, boolean isSingleFile, boolean shouldFastForward) {
@@ -460,7 +460,7 @@ public final class Notifications {
 
 		Intent cancelIntent = new Intent(context, DownloadService.class);
 		cancelIntent.setAction(DownloadService.CANCEL_DOWNLOADS);
-		PendingIntent cancelPI = PendingIntent.getService(context, 0, cancelIntent, 0);
+		PendingIntent cancelPI = PendingIntent.getService(context, 0, cancelIntent, /* flags */ PendingIntent.FLAG_IMMUTABLE);
 
 		String currentDownloading, currentSize;
 		if(file != null) {
@@ -488,7 +488,7 @@ public final class Notifications {
 		Intent notificationIntent = new Intent(context, SubsonicFragmentActivity.class);
 		notificationIntent.putExtra(Constants.INTENT_EXTRA_NAME_DOWNLOAD_VIEW, true);
 		notificationIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-		builder.setContentIntent(PendingIntent.getActivity(context, 2, notificationIntent, 0));
+		builder.setContentIntent(PendingIntent.getActivity(context, 2, notificationIntent, /* flags */ PendingIntent.FLAG_IMMUTABLE));
 
 		final Notification notification = builder.build();
 		downloadShowing = true;
@@ -605,7 +605,7 @@ public final class Notifications {
 				notificationIntent.putExtra(Constants.INTENT_EXTRA_NAME_ID, extraId);
 			}
 
-			builder.setContentIntent(PendingIntent.getActivity(context, stringId, notificationIntent, 0));
+			builder.setContentIntent(PendingIntent.getActivity(context, stringId, notificationIntent, /* flags */ PendingIntent.FLAG_IMMUTABLE));
 
 			NotificationManager notificationManager = (NotificationManager) context.getSystemService(Context.NOTIFICATION_SERVICE);
 			notificationManager.notify(stringId, builder.build());

--- a/app/src/main/java/github/paroj/dsub2000/util/compat/RemoteControlClientICS.java
+++ b/app/src/main/java/github/paroj/dsub2000/util/compat/RemoteControlClientICS.java
@@ -34,7 +34,7 @@ public class RemoteControlClientICS extends RemoteControlClientBase {
 		// build the PendingIntent for the remote control client
 		Intent mediaButtonIntent = new Intent(Intent.ACTION_MEDIA_BUTTON);
 		mediaButtonIntent.setComponent(mediaButtonReceiverComponent);
-		PendingIntent mediaPendingIntent = PendingIntent.getBroadcast(context.getApplicationContext(), 0, mediaButtonIntent, 0);
+		PendingIntent mediaPendingIntent = PendingIntent.getBroadcast(context.getApplicationContext(), 0, mediaButtonIntent, /* flags */ PendingIntent.FLAG_IMMUTABLE);
 
 		// create and register the remote control client
 		mRemoteControl = new RemoteControlClient(mediaPendingIntent);

--- a/app/src/main/java/github/paroj/dsub2000/util/compat/RemoteControlClientLP.java
+++ b/app/src/main/java/github/paroj/dsub2000/util/compat/RemoteControlClientLP.java
@@ -83,12 +83,12 @@ public class RemoteControlClientLP extends RemoteControlClientBase {
 	@Override
 	public void register(Context context, ComponentName mediaButtonReceiverComponent) {
 		downloadService = (DownloadService) context;
-		mediaSession = new MediaSessionCompat(downloadService, "DSub MediaSession");
 
 		Intent mediaButtonIntent = new Intent(Intent.ACTION_MEDIA_BUTTON);
 		mediaButtonIntent.setComponent(mediaButtonReceiverComponent);
 		PendingIntent mediaPendingIntent = PendingIntent.getBroadcast(context.getApplicationContext(), 0, mediaButtonIntent, /* flags */ PendingIntent.FLAG_IMMUTABLE);
-		mediaSession.setMediaButtonReceiver(mediaPendingIntent);
+
+		mediaSession = new MediaSessionCompat(downloadService, "DSub MediaSession", null, mediaPendingIntent);
 
 		Intent activityIntent = new Intent(context, SubsonicFragmentActivity.class);
 		activityIntent.putExtra(Constants.INTENT_EXTRA_NAME_DOWNLOAD, true);

--- a/app/src/main/java/github/paroj/dsub2000/util/compat/RemoteControlClientLP.java
+++ b/app/src/main/java/github/paroj/dsub2000/util/compat/RemoteControlClientLP.java
@@ -87,13 +87,13 @@ public class RemoteControlClientLP extends RemoteControlClientBase {
 
 		Intent mediaButtonIntent = new Intent(Intent.ACTION_MEDIA_BUTTON);
 		mediaButtonIntent.setComponent(mediaButtonReceiverComponent);
-		PendingIntent mediaPendingIntent = PendingIntent.getBroadcast(context.getApplicationContext(), 0, mediaButtonIntent, 0);
+		PendingIntent mediaPendingIntent = PendingIntent.getBroadcast(context.getApplicationContext(), 0, mediaButtonIntent, /* flags */ PendingIntent.FLAG_IMMUTABLE);
 		mediaSession.setMediaButtonReceiver(mediaPendingIntent);
 
 		Intent activityIntent = new Intent(context, SubsonicFragmentActivity.class);
 		activityIntent.putExtra(Constants.INTENT_EXTRA_NAME_DOWNLOAD, true);
 		activityIntent.addFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
-		PendingIntent activityPendingIntent = PendingIntent.getActivity(context, 0, activityIntent, 0);
+		PendingIntent activityPendingIntent = PendingIntent.getActivity(context, 0, activityIntent, /* flags */ PendingIntent.FLAG_IMMUTABLE);
 		mediaSession.setSessionActivity(activityPendingIntent);
 
 		mediaSession.setFlags(MediaSessionCompat.FLAG_HANDLES_TRANSPORT_CONTROLS | MediaSessionCompat.FLAG_HANDLES_MEDIA_BUTTONS);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -672,7 +672,8 @@
 	<string name="details.home_page">Home Page</string>
 
 	<string name="permission.external_storage.failed">DSub2000 cannot function without the ability to write to storage</string>
-	<string name="permission.location.failed">This apps uses location data to get the WIFI SSID to match against your local network settings. To get rid of this message, change the local network SSID to blank.</string>
+	<string name="permission.location.failed">This app uses location data to get the WIFI SSID to match against your local network settings. To get rid of this message, change the local network SSID to blank.</string>
+	<string name="permission.phone_state.failed">Without the phone state permission this app will not stop playback during calls.</string>
 
     <plurals name="select_album_n_songs">
         <item quantity="zero">No songs</item>


### PR DESCRIPTION
Google Play Protect seems to warn loudly about apps targeting sdk version <33.

This PR upgrades to that version. See the individual commits for specific things that needed changing.
`gradlew` builds fine so I hope CI is unaffected this time :)

I’m a bit unhappy with the READ_PHONE_STATE permission handling. If the permission isn’t granted, a respective toast is shown each time the app starts, so maybe this should be a setting instead, but that’s too much work for now.