### PR TITLE
Fix error in cache cleaning

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/service/DownloadService.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/DownloadService.java
@@ -1086,7 +1086,7 @@ public class DownloadService extends Service {
 	public synchronized List<DownloadFile> getRecentDownloads() {
 		int from = Math.max(currentPlayingIndex - 10, 0);
 		int songsToKeep = Math.min(Math.max(Util.getPreloadCount(this), 20), downloadList.size());
-		int to = Math.min(currentPlayingIndex + songsToKeep, Math.max(downloadList.size() - 1, 0));
+		int to = Math.max(Math.min(currentPlayingIndex + songsToKeep, downloadList.size() - 1), 0);
 		List<DownloadFile> temp = downloadList.subList(from, to);
 		temp.addAll(backgroundDownloadList);
 		return temp;


### PR DESCRIPTION
I believe this exception is thrown when the cache was cleaned and no tracks are queued, as `currentPlayingIndex + songsToKeep` would come out to `-1 + 0`.


<details><summary>stack trace</summary>

```
07-22 07:10:45.853 16481 16513 E CacheCleaner: Error in cache cleaning.
07-22 07:10:45.853 16481 16513 E CacheCleaner: java.lang.IllegalArgumentException: fromIndex(0) > toIndex(-1)
07-22 07:10:45.853 16481 16513 E CacheCleaner: 	at java.util.AbstractList.subListRangeCheck(AbstractList.java:511)
07-22 07:10:45.853 16481 16513 E CacheCleaner: 	at java.util.ArrayList.subList(ArrayList.java:1207)
07-22 07:10:45.853 16481 16513 E CacheCleaner: 	at github.paroj.dsub2000.service.DownloadService.getRecentDownloads(DownloadService.java:1090)
07-22 07:10:45.853 16481 16513 E CacheCleaner: 	at github.paroj.dsub2000.util.CacheCleaner.findUndeletableFiles(CacheCleaner.java:154)
07-22 07:10:45.853 16481 16513 E CacheCleaner: 	at github.paroj.dsub2000.util.CacheCleaner.access$500(CacheCleaner.java:25)
07-22 07:10:45.853 16481 16513 E CacheCleaner: 	at github.paroj.dsub2000.util.CacheCleaner$BackgroundCleanup.doInBackground(CacheCleaner.java:218)
07-22 07:10:45.853 16481 16513 E CacheCleaner: 	at github.paroj.dsub2000.util.CacheCleaner$BackgroundCleanup.doInBackground(CacheCleaner.java:198)
07-22 07:10:45.853 16481 16513 E CacheCleaner: 	at github.paroj.dsub2000.util.BackgroundTask$Task.execute(BackgroundTask.java:214)
07-22 07:10:45.853 16481 16513 E CacheCleaner: 	at github.paroj.dsub2000.util.BackgroundTask$Task.access$300(BackgroundTask.java:200)
07-22 07:10:45.853 16481 16513 E CacheCleaner: 	at github.paroj.dsub2000.util.BackgroundTask$TaskRunnable.run(BackgroundTask.java:325)
07-22 07:10:45.853 16481 16513 E CacheCleaner: 	at java.lang.Thread.run(Thread.java:1119)
````

</details>