### PR TITLE
Prevent ServerProxy module destruction by ProGuard

### DIFF
--- a/ServerProxy/build.gradle
+++ b/ServerProxy/build.gradle
@@ -43,13 +43,13 @@ android {
 
     buildTypes {
         release {
-            minifyEnabled true
-            proguardFiles 'proguard.cfg'
+            minifyEnabled false
+            consumerProguardFiles 'proguard.cfg'
             zipAlignEnabled true
         }
         fix {
-            minifyEnabled true
-            proguardFiles 'proguard.cfg'
+            minifyEnabled false
+            consumerProguardFiles 'proguard.cfg'
             zipAlignEnabled true
         }
     }


### PR DESCRIPTION
I noticed when trying to play Podcasts that I could only get them to work properly by going in to offline mode after caching them. So I decided to investigate this a bit further, the logcat would show the following when trying to play podcasts (Not all the time, but enought to be annoying)

`
Got exception: java.lang.NoSuchMethodError: No direct method <init>(Landroid/content/Context;)V in class Lgithub/paroj/serverproxy/BufferProxy; or its super classes (declaration of 'github.paroj.serverproxy.BufferProxy' appears in base.apk)
java.lang.NoSuchMethodError: No direct method <init>(Landroid/content/Context;)V in class Lgithub/paroj/serverproxy/BufferProxy; or its super classes (declaration of 'github.paroj.serverproxy.BufferProxy' appears in base.apk)
	at github.paroj.dsub2000.service.DownloadService.doPlay(SourceFile:161)
	at github.paroj.dsub2000.service.DownloadService$BufferTask.doInBackground(SourceFile:118)
	at github.paroj.dsub2000.util.BackgroundTask$Task.access$300(SourceFile:24)
	at github.paroj.dsub2000.util.BackgroundTask$TaskRunnable.run(SourceFile:28)
	at java.lang.Thread.run(Thread.java:764)
`

After trying many things with proguard, and even adding methods to remove the constructor completely and utilize setters, I came accross this article which explained what is going on [https://drjansari.medium.com/mastering-proguard-in-android-multi-module-projects-agp-8-4-r8-and-consumable-rules-ae28074b6f1f](https://drjansari.medium.com/mastering-proguard-in-android-multi-module-projects-agp-8-4-r8-and-consumable-rules-ae28074b6f1f)

The commit attached in this pull request implements (I hope) what that article was showing, I can confirm that after this change and I build `flossRelease` that everything works as expected. Podcasts play on first try,