### PR TITLE
Add a fake setting showing whether Chromecast support is built into the release

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/fragments/SettingsFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/SettingsFragment.java
@@ -61,6 +61,7 @@ import github.paroj.dsub2000.util.LoadingTask;
 import github.paroj.dsub2000.util.MediaRouteManager;
 import github.paroj.dsub2000.util.SyncUtil;
 import github.paroj.dsub2000.util.Util;
+import github.paroj.dsub2000.util.compat.GoogleCompat;
 import github.paroj.dsub2000.view.CacheLocationPreference;
 import github.paroj.dsub2000.view.ErrorDialog;
 import github.paroj.dsub2000.view.EditPasswordPreference;
@@ -358,6 +359,12 @@ public class SettingsFragment extends PreferenceCompatFragment implements Shared
 				serversCategory.addPreference(addServer(i));
 				serverSettings.put(String.valueOf(i), new ServerSettings(i));
 			}
+		}
+
+		CheckBoxPreference chromecastAvailabilityPreference =
+				(CheckBoxPreference) findPreference("castChromecastAvailability");
+		if (chromecastAvailabilityPreference != null) {
+			chromecastAvailabilityPreference.setChecked(GoogleCompat.castAvailable());
 		}
 
 		SharedPreferences prefs = Util.getPreferences(context);

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -498,6 +498,8 @@
 	<string name="settings.casting_cache_summary">Cache currently playing songs while casting</string>
 	<string name="settings.casting.dlna_casting_enabled">DLNA Enabled</string>
 	<string name="settings.casting.dlna_casting_enabled.summary">If you are having battery drain problems on Android 7.0 try turning this off</string>
+	<string name="settings.casting.chromecast_available">Chromecast Support</string>
+	<string name="settings.casting.chromecast_available_summary">Whether Chromecast Support is enabled in this DSub2000 release.</string>
     <string name="settings.rewind_interval">Rewind Interval</string>
     <string name="settings.fastforward_interval">Fast Forward Interval</string>
 	<string name="settings.media_style_notification">Native Android media notification (5.0+)</string>

--- a/app/src/main/res/xml/settings_cast.xml
+++ b/app/src/main/res/xml/settings_cast.xml
@@ -27,6 +27,13 @@
 			android:summary="@string/settings.casting_cache_summary"
 			android:key="castCache"
 			android:defaultValue="false"/>
+
+		<CheckBoxPreference
+			android:defaultValue="false"
+			android:enabled="false"
+			android:key="castChromecastAvailability"
+			android:summary="@string/settings.casting.chromecast_available_summary"
+			android:title="@string/settings.casting.chromecast_available" />
 	</PreferenceCategory>
 
 	<PreferenceCategory


### PR DESCRIPTION
Ideally this can help confusion such as in #38.

<img width="300" height="503" alt="image" src="https://github.com/user-attachments/assets/e34d45e4-3c6e-489c-8fda-63990556431c" />

fixes #38 