### PR TITLE
Use embedded cover art [Fixes #75]

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/util/FileUtil.java
+++ b/app/src/main/java/github/paroj/dsub2000/util/FileUtil.java
@@ -214,6 +214,13 @@ public class FileUtil {
 			} else {
 				artFile = hexFile;
 			}
+
+			// If the cover art ID is the same as the song ID, it's embedded.
+			// In that case, use the song ID in the filename to make it unique.
+			if (entry.getCoverArt() != null && entry.getCoverArt().equals(entry.getId())) {
+				artFile = new File(albumDir, entry.getId() + ".jpg");
+			}
+
 			return artFile;
 		}
     }


### PR DESCRIPTION
Displays embedded cover art when server supports them, instead of same cover art for all songs in the album.
Tested with [gonic](https://github.com/sentriz/gonic) and [navidrome](https://github.com/navidrome/navidrome) servers.

Fixes #75 