### PR TITLE
Fix: Tracks are getting skipped (Closes #58)

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/service/DownloadService.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/DownloadService.java
@@ -2096,7 +2096,14 @@ public class DownloadService extends Service {
 				Log.w(TAG, "Error on playing file " + "(" + what + ", " + extra + "): " + downloadFile);
 				int pos = getPlayerPosition();
 				reset();
-				if (!isPartial || (downloadFile.isWorkDone() && (Math.abs(duration - pos) < 10000))) {
+                boolean isError38 = (what == -38 && extra == 0);
+                if (isError38) {
+                    // Occasionally, an "Invalid state" error (-38) may occur
+                    // because the player state is not handled correctly in this
+                    // implementation. In such cases, we simply retry the operation.
+                    Log.w(TAG, "Error -38 occurred – retrying to play the current song.");
+                }
+                if (!isError38 && (!isPartial || (downloadFile.isWorkDone() && (Math.abs(duration - pos) < 10000)))) {
 					playNext();
 				} else {
 					downloadFile.setPlaying(false);


### PR DESCRIPTION
As described in #58, tracks are occasionally getting skipped. As @rumpeltux found out, this is caused by a `MediaPlayer` error `-38, 0`. According to my research, this error seems to occur when the `MediaPlayer` state model isn’t followed correctly:
[https://developer.android.com/media/platform/mediaplayer/state-resources](https://developer.android.com/media/platform/mediaplayer/state-resources)

Unfortunately, I wasn’t able to fully understand the root cause or fix it myself (I’m simply not skilled enough). 

Since nobody has managed to fix this issue in the past and the app is nearing the end of its lifecycle, it might be acceptable to handle the error gracefully and simply retry playing the current track (the one that failed). The `MediaPlayer` error `-38, 0` occurs very rarely, so the risk of ending up in an endless retry loop is very unlikely.

I’ve been using an app patched with this fix for several weeks now and haven’t encountered any issues.