### PR TITLE
Improve usability by expanding touch area of “More” buttons with TouchDelegateHelper

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/adapter/SectionAdapter.java
+++ b/app/src/main/java/github/paroj/dsub2000/adapter/SectionAdapter.java
@@ -40,6 +40,7 @@ import github.paroj.dsub2000.R;
 import github.paroj.dsub2000.activity.SubsonicFragmentActivity;
 import github.paroj.dsub2000.util.Constants;
 import github.paroj.dsub2000.util.MenuUtil;
+import github.paroj.dsub2000.util.TouchDelegateUtil;
 import github.paroj.dsub2000.util.Util;
 import github.paroj.dsub2000.view.BasicHeaderView;
 import github.paroj.dsub2000.view.UpdateView;
@@ -154,6 +155,7 @@ public abstract class SectionAdapter<T> extends RecyclerView.Adapter<UpdateViewH
 							}
 						}
 					});
+                    TouchDelegateUtil.expandTouchArea(moreButton);
 
 					if(checkable) {
 						updateView.getChildAt(0).setOnLongClickListener(new View.OnLongClickListener() {

--- a/app/src/main/java/github/paroj/dsub2000/util/TouchDelegateUtil.java
+++ b/app/src/main/java/github/paroj/dsub2000/util/TouchDelegateUtil.java
@@ -1,0 +1,35 @@
+package github.paroj.dsub2000.util;
+
+import android.graphics.Rect;
+import android.view.TouchDelegate;
+import android.view.View;
+import github.paroj.dsub2000.R;
+
+/**
+ * Utility class to easily expand the touch area of any view without changing its visual layout.
+ */
+public class TouchDelegateUtil {
+
+    /**
+     * Expands the touch area of a view on both sides (left/right).
+     * Reads the expansion value from dimens.xml using MoreButton.TouchExpand.
+     * Can be called before or after setting an OnClickListener.
+     */
+    public static void expandTouchArea(final View view) {
+        final View parent = (View) view.getParent();
+        if (parent == null) return;
+
+        float extraDp = view.getResources().getDimension(R.dimen.View_TouchExpand);
+        final int extraPx = (int) extraDp;
+
+        parent.post(() -> {
+            Rect rect = new Rect();
+            view.getHitRect(rect);
+
+            rect.left -= extraPx;
+            rect.right += extraPx;
+
+            parent.setTouchDelegate(new TouchDelegate(rect, view));
+        });
+    }
+}

--- a/app/src/main/java/github/paroj/dsub2000/util/TouchDelegateUtil.java
+++ b/app/src/main/java/github/paroj/dsub2000/util/TouchDelegateUtil.java
@@ -12,7 +12,7 @@ public class TouchDelegateUtil {
 
     /**
      * Expands the touch area of a view on both sides (left/right).
-     * Reads the expansion value from dimens.xml using MoreButton.TouchExpand.
+     * Reads the expansion value from dimens.xml using View.TouchExpand.
      * Can be called before or after setting an OnClickListener.
      */
     public static void expandTouchArea(final View view) {

--- a/app/src/main/java/github/paroj/dsub2000/view/ArtistEntryView.java
+++ b/app/src/main/java/github/paroj/dsub2000/view/ArtistEntryView.java
@@ -27,6 +27,7 @@ import android.widget.TextView;
 import github.paroj.dsub2000.R;
 import github.paroj.dsub2000.domain.MusicDirectory;
 import github.paroj.dsub2000.util.FileUtil;
+import github.paroj.dsub2000.util.TouchDelegateUtil;
 
 import java.io.File;
 /**
@@ -53,6 +54,7 @@ public class ArtistEntryView extends UpdateView<MusicDirectory.Entry> {
 				v.showContextMenu();
 			}
 		});
+        TouchDelegateUtil.expandTouchArea(moreButton);
     }
     
     protected void setObjectImpl(MusicDirectory.Entry artist) {

--- a/app/src/main/java/github/paroj/dsub2000/view/ArtistView.java
+++ b/app/src/main/java/github/paroj/dsub2000/view/ArtistView.java
@@ -27,6 +27,7 @@ import android.widget.TextView;
 import github.paroj.dsub2000.R;
 import github.paroj.dsub2000.domain.Artist;
 import github.paroj.dsub2000.util.FileUtil;
+import github.paroj.dsub2000.util.TouchDelegateUtil;
 
 import java.io.File;
 
@@ -54,6 +55,7 @@ public class ArtistView extends UpdateView<Artist> {
 				v.showContextMenu();
 			}
 		});
+        TouchDelegateUtil.expandTouchArea(moreButton);
     }
     
     protected void setObjectImpl(Artist artist) {

--- a/app/src/main/java/github/paroj/dsub2000/view/PodcastChannelView.java
+++ b/app/src/main/java/github/paroj/dsub2000/view/PodcastChannelView.java
@@ -29,6 +29,8 @@ import github.paroj.dsub2000.domain.PodcastChannel;
 import github.paroj.dsub2000.util.ImageLoader;
 import github.paroj.dsub2000.util.SyncUtil;
 import github.paroj.dsub2000.util.FileUtil;
+import github.paroj.dsub2000.util.TouchDelegateUtil;
+
 import java.io.File;
 
 public class PodcastChannelView extends UpdateView<PodcastChannel> {
@@ -62,6 +64,7 @@ public class PodcastChannelView extends UpdateView<PodcastChannel> {
 				v.showContextMenu();
 			}
 		});
+        TouchDelegateUtil.expandTouchArea(moreButton);
 		coverArtView = findViewById(R.id.item_art);
 	}
 

--- a/app/src/main/java/github/paroj/dsub2000/view/ShareView.java
+++ b/app/src/main/java/github/paroj/dsub2000/view/ShareView.java
@@ -30,6 +30,7 @@ import java.util.Locale;
 
 import github.paroj.dsub2000.R;
 import github.paroj.dsub2000.domain.Share;
+import github.paroj.dsub2000.util.TouchDelegateUtil;
 
 public class ShareView extends UpdateView<Share> {
 	private static final String TAG = ShareView.class.getSimpleName();
@@ -51,6 +52,7 @@ public class ShareView extends UpdateView<Share> {
 				v.showContextMenu();
 			}
 		});
+        TouchDelegateUtil.expandTouchArea(moreButton);
 	}
 
 	public void setObjectImpl(Share share) {

--- a/app/src/main/java/github/paroj/dsub2000/view/UserView.java
+++ b/app/src/main/java/github/paroj/dsub2000/view/UserView.java
@@ -24,6 +24,7 @@ import android.widget.TextView;
 import github.paroj.dsub2000.R;
 import github.paroj.dsub2000.domain.User;
 import github.paroj.dsub2000.util.ImageLoader;
+import github.paroj.dsub2000.util.TouchDelegateUtil;
 
 public class UserView extends UpdateView2<User, ImageLoader> {
 	private TextView usernameView;
@@ -41,6 +42,7 @@ public class UserView extends UpdateView2<User, ImageLoader> {
 				v.showContextMenu();
 			}
 		});
+        TouchDelegateUtil.expandTouchArea(moreButton);
 	}
 
 	protected void setObjectImpl(User user, ImageLoader imageLoader) {

--- a/app/src/main/res/values/dimens.xml
+++ b/app/src/main/res/values/dimens.xml
@@ -13,4 +13,5 @@
 	<dimen name="FastScroller.LeftAlignedMargin">6dp</dimen>
 	<dimen name="FastScroller.NormalBarMargin">4dp</dimen>
 	<dimen name="FastScroller.RightMargin">4dp</dimen>
+    <dimen name="View.TouchExpand">8dp</dimen>
 </resources>


### PR DESCRIPTION
This pull request introduces a new utility class, **`TouchDelegateHelper`**, which expands the touch area of small UI elements - specifically the “More” buttons used throughout the app.

**Motivation:**  
While adding songs to my local DSub2000 playlist, I frequently tried to add more tracks by tapping the “More” button in search results. Sometimes I would *just miss* the button, causing the song to play immediately. This **resets the entire prepared playlist**, which is frustrating.  

By increasing the clickable area of the “More” buttons, this PR reduces the chance of missed taps, improving usability and preventing playlist loss.

## Key changes

- Added `TouchDelegateHelper` utility  
  - Expands the touch area of a target view using Android’s `TouchDelegate`  
  - Reads the expansion value from the centralized dimension resource:  
    ```xml
    <dimen name="View.TouchExpand">8dp</dimen>
    ```  
  - Can be applied with a **single line of code** wherever a “More” button is created

- Updated adapters to use the helper:  
    ```java
    TouchDelegateHelper.expandTouchArea(moreButton);
    ```

- **Visual layout remains unchanged**

<img width="357" height="795" alt="grafik" src="https://github.com/user-attachments/assets/38a214dc-39ae-4d8f-a98b-47d1e6d71efa" />

## Testing

- Verified in Android Emulator using **Pointer Location** to confirm expanded touch areas  
- Confirmed correct behavior across multiple list screens (Songs, Albums, Playlists)  
- Ensured no visual layout changes occur