### PR TITLE
Respect “Per Folder” setting in Random Song feature

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/adapter/EntryInfiniteGridAdapter.java
+++ b/app/src/main/java/github/paroj/dsub2000/adapter/EntryInfiniteGridAdapter.java
@@ -132,7 +132,7 @@ public class EntryInfiniteGridAdapter extends EntryGridAdapter {
 		} else if("genres".equals(type) || "genres-songs".equals(type)) {
 			result = service.getSongsByGenre(extra, size, offset, context, null);
 		} else if (type.equals("randomsongs")) {
-			result = service.getRandomTracks(size, context, null);
+			result = service.getRandomSongs(size, context, null);
 		}else if(type.indexOf(MainFragment.SONGS_LIST_PREFIX) != -1) {
 			result = service.getSongList(type, size, offset, context, null);
 		} else {

--- a/app/src/main/java/github/paroj/dsub2000/fragments/SelectDirectoryFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/SelectDirectoryFragment.java
@@ -46,7 +46,6 @@ import github.paroj.dsub2000.service.DownloadService;
 import github.paroj.dsub2000.util.DrawableTint;
 import github.paroj.dsub2000.util.ImageLoader;
 
-import java.io.Serializable;
 import java.util.List;
 
 import github.paroj.dsub2000.domain.PodcastEpisode;
@@ -554,7 +553,7 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 			setTitle(albumListExtra);
 		} else if("alphabeticalByName".equals(albumListType)) {
 			setTitle(R.string.main_albums_alphabetical);
-		} if (MainFragment.SONGS_NEWEST.equals(albumListType)) {
+		} else if (MainFragment.SONGS_NEWEST.equals(albumListType)) {
 			setTitle(R.string.main_songs_newest);
 		} else if (MainFragment.SONGS_TOP_PLAYED.equals(albumListType)) {
 			setTitle(R.string.main_songs_top_played);
@@ -579,7 +578,7 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 				} else if("genres".equals(albumListType) || "genres-songs".equals(albumListType)) {
 					result = service.getSongsByGenre(albumListExtra, size, 0, context, this);
 				} else if("randomsongs".equals(albumListType)) {
-					result = service.getRandomTracks(size,context, this);
+					result = service.getRandomSongs(size,context, this);
 				}  else if(albumListType.indexOf(MainFragment.SONGS_LIST_PREFIX) != -1) {
 					result = service.getSongList(albumListType, size, 0, context, this);
 				} else {

--- a/app/src/main/java/github/paroj/dsub2000/service/CachedMusicService.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/CachedMusicService.java
@@ -686,8 +686,8 @@ public class CachedMusicService implements MusicService {
 	}
 
 	@Override
-	public MusicDirectory getRandomTracks(int size, Context context, ProgressListener progressListener) throws Exception {
-		return musicService.getRandomTracks(size, context, progressListener);
+	public MusicDirectory getRandomSongs(int size, Context context, ProgressListener progressListener) throws Exception {
+		return musicService.getRandomSongs(size, context, progressListener);
 	}
 
 	@Override

--- a/app/src/main/java/github/paroj/dsub2000/service/MusicService.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/MusicService.java
@@ -97,7 +97,7 @@ public interface MusicService {
 
 	MusicDirectory getRandomSongs(int size, String artistId, Context context, ProgressListener progressListener) throws Exception;
     MusicDirectory getRandomSongs(int size, String folder, String genre, String startYear, String endYear, Context context, ProgressListener progressListener) throws Exception;
-	MusicDirectory getRandomTracks(int size, Context context, ProgressListener progressListener) throws Exception;
+	MusicDirectory getRandomSongs(int size, Context context, ProgressListener progressListener) throws Exception;
 
 	String getCoverArtUrl(Context context, MusicDirectory.Entry entry) throws Exception;
 

--- a/app/src/main/java/github/paroj/dsub2000/service/OfflineMusicService.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/OfflineMusicService.java
@@ -598,7 +598,7 @@ public class OfflineMusicService implements MusicService {
 	}
 
 	@Override
-	public MusicDirectory getRandomTracks(int size, Context context, ProgressListener progressListener) throws Exception {
+	public MusicDirectory getRandomSongs(int size, Context context, ProgressListener progressListener) throws Exception {
 		throw new OfflineException(ERRORMSG);
 	}
 

--- a/app/src/main/java/github/paroj/dsub2000/service/RESTMusicService.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/RESTMusicService.java
@@ -735,12 +735,22 @@ public class RESTMusicService implements MusicService {
     }
 
     @Override
-    public MusicDirectory getRandomTracks(int size, Context context, ProgressListener progressListener) throws Exception {
+    public MusicDirectory getRandomSongs(int size, Context context, ProgressListener progressListener) throws Exception {
         List<String> names = new ArrayList<String>();
         List<Object> values = new ArrayList<Object>();
 
         names.add("size");
         values.add(size);
+
+        // Add folder if it was set and is non null
+        int instance = getInstance(context);
+        if(Util.getAlbumListsPerFolder(context, instance)) {
+            String folderId = Util.getSelectedMusicFolderId(context, instance);
+            if(folderId != null) {
+                names.add("musicFolderId");
+                values.add(folderId);
+            }
+        }
 
         Reader reader = getReader(context, progressListener, "getRandomSongs", names, values);
         try {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -68,6 +68,7 @@
 	<string name="main.albums_year">Jahrzehnt</string>
 	<string name="main.albums_alphabetical">Alphabetisch</string>
 	<string name="main.videos">Videos</string>
+    <string name="main.songs_random">@string/main.albums_random</string>
 	<string name="main.songs_genres">@string/main.albums_genres</string>
 	<string name="main.back_confirm">Zum beenden nochmal zurück drücken</string>
 	<string name="main.scan_complete">Durchsuchen des Server abgeschlossen</string>

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -62,6 +62,7 @@
     <string name="main.albums_random">Au hasard</string>
 	<string name="main.albums_genres">Par genres</string>
 	<string name="main.albums_year">Par décennies</string>
+    <string name="main.songs_random">@string/main.albums_random</string>
 	<string name="main.songs_genres">@string/main.albums_genres</string>
 	<string name="main.back_confirm">Presser retour à nouveau pour quitter</string>
 	<string name="main.scan_complete">Analyse du server terminée</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -74,6 +74,7 @@
 	<string name="main.albums_year">Évtizedek</string>
 	<string name="main.albums_alphabetical">Betűrendben</string>
 	<string name="main.videos">Videók</string>
+    <string name="main.songs_random">@string/main.albums_random</string>
 	<string name="main.songs_genres">@string/main.albums_genres</string>
 	<string name="main.songs_newest">@string/main.albums_newest</string>
 	<string name="main.songs_top_played">Top Played</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -71,6 +71,7 @@
 	<string name="main.albums_year">Decennia</string>
 	<string name="main.albums_alphabetical">Alfabetisch</string>
 	<string name="main.videos">Video\'s</string>
+    <string name="main.songs_random">@string/main.albums_random</string>
 	<string name="main.songs_genres">@string/main.albums_genres</string>
 	<string name="main.back_confirm">Druk nogmaals terug om te stoppen</string>
 	<string name="main.scan_complete">Server scan afgerond</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -73,6 +73,7 @@
 	<string name="main.albums_year">Décadas</string>
 	<string name="main.albums_alphabetical">Alfabeticamente</string>
 	<string name="main.videos">Vídeos</string>
+    <string name="main.songs_random">@string/main.albums_random</string>
 	<string name="main.songs_genres">@string/main.albums_genres</string>
 	<string name="main.songs_newest">@string/main.albums_newest</string>
 	<string name="main.songs_top_played">Top de reproduções</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -73,6 +73,7 @@
 	<string name="main.albums_year">Årtionden</string>
 	<string name="main.albums_alphabetical">Alfabetiskt</string>
 	<string name="main.videos">Videor</string>
+    <string name="main.songs_random">@string/main.albums_random</string>
 	<string name="main.songs_genres">@string/main.albums_genres</string>
 	<string name="main.back_confirm">Tryck bakåt igen för att avsluta</string>
 	<string name="main.scan_complete">Skanning av server klar</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -235,6 +235,7 @@
     <string name="main.scan_complete">已完成对服务器的扫描</string>
     <string name="main.settings">设置</string>
     <string name="main.shuffle">随机播放</string>
+    <string name="main.songs_random">@string/main.albums_random</string>
     <string name="main.songs_top_played">最高播放</string>
     <string name="main.title">标题</string>
     <string name="main.videos">视频</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -74,7 +74,7 @@
 	<string name="main.albums_year">Decades</string>
 	<string name="main.albums_alphabetical">Alphabetically</string>
 	<string name="main.videos">Videos</string>
-	<string name="main.songs_random">Random</string>
+	<string name="main.songs_random">@string/main.albums_random</string>
 	<string name="main.songs_genres">@string/main.albums_genres</string>
 	<string name="main.songs_newest">@string/main.albums_newest</string>
 	<string name="main.songs_top_played">Top Played</string>


### PR DESCRIPTION
### Motivation
On my Airsonic server I’m using multiple media folders - one containing audiobooks and another containing music albums. With the random song feature introduced in PR #6, tracks from all media folders were played together, mixing audiobooks and albums. DSub2000 already provides a **“Per Folder”** checkbox to restrict playback to the currently selected media folder, but this setting was not respected by the random song feature.

### Updates
- Random song feature now respects the **“Per Folder”** checkbox  

### Refactoring
- Reuse of existing `@string/main.albums_random` label for “Random”  
- Added translation for the reused “Random” label  
- Renamed `getRandomTracks` to `getRandomSongs`  
- Small if/else fix in `SelectDirectoryFragment`
