### PR TITLE
Improve usability by separating "Starred" songs and albums

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/domain/repository/StarredRepository.java
+++ b/app/src/main/java/github/paroj/dsub2000/domain/repository/StarredRepository.java
@@ -1,0 +1,25 @@
+package github.paroj.dsub2000.domain.repository;
+
+import android.content.Context;
+
+import java.util.List;
+
+import github.paroj.dsub2000.domain.MusicDirectory;
+import github.paroj.dsub2000.service.MusicService;
+import github.paroj.dsub2000.util.ProgressListener;
+
+public final class StarredUtil {
+    public static MusicDirectory getStarredAlbumsList(MusicService service, Context context, ProgressListener progressListener) throws Exception {
+        return getStarredFilteredList(service, context, progressListener, true, false);
+    }
+
+    public static MusicDirectory getStarredSongsList(MusicService service, Context context, ProgressListener progressListener) throws Exception {
+        return getStarredFilteredList(service, context, progressListener, false, true);
+    }
+
+    private static MusicDirectory getStarredFilteredList(MusicService service, Context context, ProgressListener progressListener, boolean includeDirs, boolean includeFiles) throws Exception {
+        MusicDirectory result = service.getStarredList(context, progressListener);
+        List<MusicDirectory.Entry> children = result.getChildren(includeDirs, includeFiles);
+        return new MusicDirectory(children);
+    }
+}

--- a/app/src/main/java/github/paroj/dsub2000/domain/repository/StarredRepository.java
+++ b/app/src/main/java/github/paroj/dsub2000/domain/repository/StarredRepository.java
@@ -8,17 +8,29 @@ import github.paroj.dsub2000.domain.MusicDirectory;
 import github.paroj.dsub2000.service.MusicService;
 import github.paroj.dsub2000.util.ProgressListener;
 
-public final class StarredUtil {
-    public static MusicDirectory getStarredAlbumsList(MusicService service, Context context, ProgressListener progressListener) throws Exception {
-        return getStarredFilteredList(service, context, progressListener, true, false);
+public final class StarredRepository {
+
+    private final MusicService musicService;
+    private final Context context;
+
+    public StarredRepository(MusicService musicService, Context context) {
+        this.musicService = musicService;
+        this.context = context;
     }
 
-    public static MusicDirectory getStarredSongsList(MusicService service, Context context, ProgressListener progressListener) throws Exception {
-        return getStarredFilteredList(service, context, progressListener, false, true);
+    public MusicDirectory getStarredAlbums(ProgressListener progressListener) throws Exception {
+        return getFilteredStarredList(progressListener, true, false);
     }
 
-    private static MusicDirectory getStarredFilteredList(MusicService service, Context context, ProgressListener progressListener, boolean includeDirs, boolean includeFiles) throws Exception {
-        MusicDirectory result = service.getStarredList(context, progressListener);
+    public MusicDirectory getStarredSongs(ProgressListener progressListener) throws Exception {
+        return getFilteredStarredList(progressListener, false, true);
+    }
+
+    private MusicDirectory getFilteredStarredList(ProgressListener progressListener,
+                                                  boolean includeDirs,
+                                                  boolean includeFiles) throws Exception {
+
+        MusicDirectory result = musicService.getStarredList(context, progressListener);
         List<MusicDirectory.Entry> children = result.getChildren(includeDirs, includeFiles);
         return new MusicDirectory(children);
     }

--- a/app/src/main/java/github/paroj/dsub2000/fragments/MainFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/MainFragment.java
@@ -149,6 +149,7 @@ public class MainFragment extends SelectRecyclerFragment<Integer> {
 		if(ServerInfo.checkServerVersion(context, "1.2.0")) {
 			songs.add(R.string.main_songs_random);
 		}
+        songs.add(R.string.main_songs_starred);
 
 		sections.add(songs);
 		headers.add("songs");
@@ -418,8 +419,10 @@ public class MainFragment extends SelectRecyclerFragment<Integer> {
 		} else if (item == R.string.main_albums_frequent) {
 			showAlbumList("frequent");
 		} else if (item == R.string.main_albums_starred) {
-			showAlbumList("starred");
-		} else if(item == R.string.main_albums_genres) {
+			showAlbumList("starredalbums");
+		} else if (item == R.string.main_songs_starred) {
+            showAlbumList("starredsongs");
+        } else if(item == R.string.main_albums_genres) {
 			showAlbumList("genres");
 		} else if(item == R.string.main_albums_year) {
 			showAlbumList("years");

--- a/app/src/main/java/github/paroj/dsub2000/fragments/SelectDirectoryFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/SelectDirectoryFragment.java
@@ -2,6 +2,8 @@ package github.paroj.dsub2000.fragments;
 
 import android.annotation.TargetApi;
 import androidx.appcompat.app.AlertDialog;
+
+import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -56,6 +58,7 @@ import github.paroj.dsub2000.service.ServerTooOldException;
 import github.paroj.dsub2000.util.Constants;
 import github.paroj.dsub2000.util.LoadingTask;
 import github.paroj.dsub2000.util.Pair;
+import github.paroj.dsub2000.util.ProgressListener;
 import github.paroj.dsub2000.util.SilentBackgroundTask;
 import github.paroj.dsub2000.util.TabBackgroundTask;
 import github.paroj.dsub2000.util.UpdateHelper;
@@ -225,7 +228,7 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 	public void onCreateOptionsMenu(Menu menu, MenuInflater menuInflater) {
 		if(licenseValid == null) {
 			menuInflater.inflate(R.menu.empty, menu);
-		} else if(albumListType != null && !"starred".equals(albumListType)) {
+		} else if(albumListType != null && !albumListType.startsWith("starred")) {
 			menuInflater.inflate(R.menu.select_album_list, menu);
 		} else if(artist && !showAll) {
 			menuInflater.inflate(R.menu.select_album, menu);
@@ -273,7 +276,7 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 			}
 		}
 
-		if("starred".equals(albumListType)) {
+		if(albumListType.startsWith("starred")) {
 			menuInflater.inflate(R.menu.unstar, menu);
 		}
 	}
@@ -360,7 +363,7 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 
 			onSongPress(Arrays.asList(entry), entry, false);
 		} else {
-			onSongPress(entries, entry, albumListType == null || "starred".equals(albumListType));
+			onSongPress(entries, entry, albumListType == null || albumListType.startsWith("starred"));
 		}
 	}
 
@@ -547,9 +550,11 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 			setTitle(R.string.main_albums_recent);
 		} else if ("frequent".equals(albumListType)) {
 			setTitle(R.string.main_albums_frequent);
-		} else if ("starred".equals(albumListType)) {
+		} else if ("starredalbums".equals(albumListType)) {
 			setTitle(R.string.main_albums_starred);
-		} else if("genres".equals(albumListType) || "years".equals(albumListType)) {
+		} else if ("starredsongs".equals(albumListType)) {
+            setTitle(R.string.main_songs_starred);
+        } else if("genres".equals(albumListType) || "years".equals(albumListType)) {
 			setTitle(albumListExtra);
 		} else if("alphabeticalByName".equals(albumListType)) {
 			setTitle(R.string.main_albums_alphabetical);
@@ -567,9 +572,11 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 			@Override
 			protected MusicDirectory load(MusicService service) throws Exception {
 				MusicDirectory result;
-				if ("starred".equals(albumListType)) {
-					result = service.getStarredList(context, this);
-				} else if(("genres".equals(albumListType) && ServerInfo.checkServerVersion(context, "1.10.0")) || "years".equals(albumListType)) {
+				if ("starredalbums".equals(albumListType)) {
+					result = getStarredAlbumsList(service, context, this);
+				} else if ("starredsongs".equals(albumListType)) {
+                    result = getStarredSongsList(service, context, this);
+                } else if(("genres".equals(albumListType) && ServerInfo.checkServerVersion(context, "1.10.0")) || "years".equals(albumListType)) {
 					result = service.getAlbumList(albumListType, albumListExtra, size, 0, refresh, context, this);
 					if(result.getChildrenSize() == 0 && "genres".equals(albumListType)) {
 						SelectDirectoryFragment.this.albumListType = "genres-songs";
@@ -692,7 +699,7 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 			recyclerView.setVisibility(View.VISIBLE);
 		}
 
-		if(albumListType == null || "starred".equals(albumListType)) {
+		if(albumListType == null || albumListType.startsWith("starred")) {
 			entryGridAdapter = new EntryGridAdapter(context, entries, getImageLoader(), largeAlbums);
 			entryGridAdapter.setRemoveFromPlaylist(playlistId != null);
 		} else {
@@ -824,7 +831,7 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 	private void playAll(final boolean shuffle, final boolean append, final boolean playNext) {
 		boolean hasSubFolders = albums != null && !albums.isEmpty();
 
-		if (hasSubFolders && (id != null || share != null || "starred".equals(albumListType))) {
+		if (hasSubFolders && (id != null || share != null || albumListType.startsWith("starred"))) {
 			downloadRecursively(id, false, append, !append, shuffle, false, playNext);
 		} else if(hasSubFolders && albumListType != null) {
 			downloadRecursively(albums, shuffle, append, playNext);
@@ -968,7 +975,7 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 	@Override
 	protected void toggleSelectedStarred() {
 		UpdateHelper.OnStarChange onStarChange = null;
-		if(albumListType != null && "starred".equals(albumListType)) {
+		if(albumListType != null && albumListType.startsWith("starred")) {
 			onStarChange = new UpdateHelper.OnStarChange() {
 				@Override
 				public void starChange(boolean starred) {
@@ -1349,4 +1356,18 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 			ratingBar.setVisibility(View.GONE);
 		}
 	}
+
+    private MusicDirectory getStarredAlbumsList(MusicService service, Context context, ProgressListener progressListener) throws Exception {
+        return getStarredFilteredList(service, context, progressListener, true, false);
+    }
+
+    private MusicDirectory getStarredSongsList(MusicService service, Context context, ProgressListener progressListener) throws Exception {
+        return getStarredFilteredList(service, context, progressListener, false, true);
+    }
+
+    private MusicDirectory getStarredFilteredList(MusicService service, Context context, ProgressListener progressListener, boolean includeDirs, boolean includeFiles) throws Exception {
+        MusicDirectory result = service.getStarredList(context, progressListener);
+        List<Entry> children = result.getChildren(includeDirs, includeFiles);
+        return new MusicDirectory(children);
+    }
 }

--- a/app/src/main/java/github/paroj/dsub2000/fragments/SelectDirectoryFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/SelectDirectoryFragment.java
@@ -3,7 +3,6 @@ package github.paroj.dsub2000.fragments;
 import android.annotation.TargetApi;
 import androidx.appcompat.app.AlertDialog;
 
-import android.content.Context;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
@@ -55,10 +54,10 @@ import github.paroj.dsub2000.service.MusicService;
 import github.paroj.dsub2000.service.MusicServiceFactory;
 import github.paroj.dsub2000.service.OfflineException;
 import github.paroj.dsub2000.service.ServerTooOldException;
+import github.paroj.dsub2000.domain.repository.StarredRepository;
 import github.paroj.dsub2000.util.Constants;
 import github.paroj.dsub2000.util.LoadingTask;
 import github.paroj.dsub2000.util.Pair;
-import github.paroj.dsub2000.util.ProgressListener;
 import github.paroj.dsub2000.util.SilentBackgroundTask;
 import github.paroj.dsub2000.util.TabBackgroundTask;
 import github.paroj.dsub2000.util.UpdateHelper;
@@ -363,7 +362,7 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 
 			onSongPress(Arrays.asList(entry), entry, false);
 		} else {
-			onSongPress(entries, entry, albumListType == null || albumListType.startsWith("starred"));
+			onSongPress(entries, entry, albumListType == null || "starredsongs".equals(albumListType));
 		}
 	}
 
@@ -572,10 +571,11 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 			@Override
 			protected MusicDirectory load(MusicService service) throws Exception {
 				MusicDirectory result;
+                StarredRepository starredRepository = new StarredRepository(service, context);
 				if ("starredalbums".equals(albumListType)) {
-					result = getStarredAlbumsList(service, context, this);
+					result = starredRepository.getStarredAlbums(this);
 				} else if ("starredsongs".equals(albumListType)) {
-                    result = getStarredSongsList(service, context, this);
+                    result = starredRepository.getStarredSongs(this);
                 } else if(("genres".equals(albumListType) && ServerInfo.checkServerVersion(context, "1.10.0")) || "years".equals(albumListType)) {
 					result = service.getAlbumList(albumListType, albumListExtra, size, 0, refresh, context, this);
 					if(result.getChildrenSize() == 0 && "genres".equals(albumListType)) {
@@ -831,7 +831,7 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 	private void playAll(final boolean shuffle, final boolean append, final boolean playNext) {
 		boolean hasSubFolders = albums != null && !albums.isEmpty();
 
-		if (hasSubFolders && (id != null || share != null || albumListType.startsWith("starred"))) {
+		if (hasSubFolders && (id != null || share != null || "starredalbums".equals(albumListType))) {
 			downloadRecursively(id, false, append, !append, shuffle, false, playNext);
 		} else if(hasSubFolders && albumListType != null) {
 			downloadRecursively(albums, shuffle, append, playNext);
@@ -1356,18 +1356,4 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 			ratingBar.setVisibility(View.GONE);
 		}
 	}
-
-    private MusicDirectory getStarredAlbumsList(MusicService service, Context context, ProgressListener progressListener) throws Exception {
-        return getStarredFilteredList(service, context, progressListener, true, false);
-    }
-
-    private MusicDirectory getStarredSongsList(MusicService service, Context context, ProgressListener progressListener) throws Exception {
-        return getStarredFilteredList(service, context, progressListener, false, true);
-    }
-
-    private MusicDirectory getStarredFilteredList(MusicService service, Context context, ProgressListener progressListener, boolean includeDirs, boolean includeFiles) throws Exception {
-        MusicDirectory result = service.getStarredList(context, progressListener);
-        List<Entry> children = result.getChildren(includeDirs, includeFiles);
-        return new MusicDirectory(children);
-    }
 }

--- a/app/src/main/java/github/paroj/dsub2000/fragments/SubsonicFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/SubsonicFragment.java
@@ -79,6 +79,7 @@ import github.paroj.dsub2000.util.ProgressListener;
 import github.paroj.dsub2000.util.SilentBackgroundTask;
 import github.paroj.dsub2000.util.LoadingTask;
 import github.paroj.dsub2000.util.SongDBHandler;
+import github.paroj.dsub2000.domain.repository.StarredRepository;
 import github.paroj.dsub2000.util.UpdateHelper;
 import github.paroj.dsub2000.util.UserUtil;
 import github.paroj.dsub2000.util.Util;
@@ -899,6 +900,7 @@ public class SubsonicFragment extends Fragment implements SwipeRefreshLayout.OnR
 			protected Boolean doInBackground() throws Throwable {
 				musicService = MusicServiceFactory.getMusicService(context);
 				MusicDirectory root;
+                StarredRepository starredRepository = new StarredRepository(musicService, context);
 				if(share != null) {
 					root = share.getMusicDirectory();
 				}
@@ -906,7 +908,7 @@ public class SubsonicFragment extends Fragment implements SwipeRefreshLayout.OnR
 					if(id != null) {
 						root = getMusicDirectory(id, name, false, musicService, this);
 					} else {
-						root = musicService.getStarredList(context, this);
+                        root = starredRepository.getStarredAlbums(this);
 					}
 				}
 				else {

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -69,6 +69,7 @@
 	<string name="main.albums_alphabetical">Alphabetisch</string>
 	<string name="main.videos">Videos</string>
     <string name="main.songs_random">@string/main.albums_random</string>
+    <string name="main.songs_starred">@string/main.albums_starred</string>
 	<string name="main.songs_genres">@string/main.albums_genres</string>
 	<string name="main.back_confirm">Zum beenden nochmal zurück drücken</string>
 	<string name="main.scan_complete">Durchsuchen des Server abgeschlossen</string>

--- a/app/src/main/res/values-es/strings.xml
+++ b/app/src/main/res/values-es/strings.xml
@@ -52,6 +52,8 @@
     <string name="main.albums_starred">Con estrella</string>
     <string name="main.albums_random">Aleatorio</string>
 	<string name="main.albums_genres">Géneros</string>
+    <string name="main.songs_random">@string/main.albums_random</string>
+    <string name="main.songs_starred">@string/main.albums_starred</string>
 	<string name="main.back_confirm">Pulsa atrás de nuevo para salir</string>
 	<string name="main.albums_year">Décadas</string>
 	<string name="main.faq_text">

--- a/app/src/main/res/values-fr/strings.xml
+++ b/app/src/main/res/values-fr/strings.xml
@@ -63,6 +63,7 @@
 	<string name="main.albums_genres">Par genres</string>
 	<string name="main.albums_year">Par décennies</string>
     <string name="main.songs_random">@string/main.albums_random</string>
+    <string name="main.songs_starred">@string/main.albums_starred</string>
 	<string name="main.songs_genres">@string/main.albums_genres</string>
 	<string name="main.back_confirm">Presser retour à nouveau pour quitter</string>
 	<string name="main.scan_complete">Analyse du server terminée</string>

--- a/app/src/main/res/values-hu/strings.xml
+++ b/app/src/main/res/values-hu/strings.xml
@@ -75,6 +75,7 @@
 	<string name="main.albums_alphabetical">Betűrendben</string>
 	<string name="main.videos">Videók</string>
     <string name="main.songs_random">@string/main.albums_random</string>
+    <string name="main.songs_starred">@string/main.albums_starred</string>
 	<string name="main.songs_genres">@string/main.albums_genres</string>
 	<string name="main.songs_newest">@string/main.albums_newest</string>
 	<string name="main.songs_top_played">Top Played</string>

--- a/app/src/main/res/values-nl/strings.xml
+++ b/app/src/main/res/values-nl/strings.xml
@@ -72,6 +72,7 @@
 	<string name="main.albums_alphabetical">Alfabetisch</string>
 	<string name="main.videos">Video\'s</string>
     <string name="main.songs_random">@string/main.albums_random</string>
+    <string name="main.songs_starred">@string/main.albums_starred</string>
 	<string name="main.songs_genres">@string/main.albums_genres</string>
 	<string name="main.back_confirm">Druk nogmaals terug om te stoppen</string>
 	<string name="main.scan_complete">Server scan afgerond</string>

--- a/app/src/main/res/values-pt-rPT/strings.xml
+++ b/app/src/main/res/values-pt-rPT/strings.xml
@@ -74,6 +74,7 @@
 	<string name="main.albums_alphabetical">Alfabeticamente</string>
 	<string name="main.videos">Vídeos</string>
     <string name="main.songs_random">@string/main.albums_random</string>
+    <string name="main.songs_starred">@string/main.albums_starred</string>
 	<string name="main.songs_genres">@string/main.albums_genres</string>
 	<string name="main.songs_newest">@string/main.albums_newest</string>
 	<string name="main.songs_top_played">Top de reproduções</string>

--- a/app/src/main/res/values-ru/strings.xml
+++ b/app/src/main/res/values-ru/strings.xml
@@ -42,6 +42,8 @@
     <string name="main.albums_highest">Максимальный рейтинг</string>
     <string name="main.albums_starred">Закладки</string>
     <string name="main.albums_random">Случайные</string>
+    <string name="main.songs_random">@string/main.albums_random</string>
+    <string name="main.songs_starred">@string/main.albums_starred</string>
 
 	<string name="menu.search">Поиск</string>
 	<string name="menu.shuffle">Перемешать</string>

--- a/app/src/main/res/values-sv/strings.xml
+++ b/app/src/main/res/values-sv/strings.xml
@@ -74,6 +74,7 @@
 	<string name="main.albums_alphabetical">Alfabetiskt</string>
 	<string name="main.videos">Videor</string>
     <string name="main.songs_random">@string/main.albums_random</string>
+    <string name="main.songs_starred">@string/main.albums_starred</string>
 	<string name="main.songs_genres">@string/main.albums_genres</string>
 	<string name="main.back_confirm">Tryck bakåt igen för att avsluta</string>
 	<string name="main.scan_complete">Skanning av server klar</string>

--- a/app/src/main/res/values-zh/strings.xml
+++ b/app/src/main/res/values-zh/strings.xml
@@ -236,6 +236,7 @@
     <string name="main.settings">设置</string>
     <string name="main.shuffle">随机播放</string>
     <string name="main.songs_random">@string/main.albums_random</string>
+    <string name="main.songs_starred">@string/main.albums_starred</string>
     <string name="main.songs_top_played">最高播放</string>
     <string name="main.title">标题</string>
     <string name="main.videos">视频</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -75,6 +75,7 @@
 	<string name="main.albums_alphabetical">Alphabetically</string>
 	<string name="main.videos">Videos</string>
 	<string name="main.songs_random">@string/main.albums_random</string>
+    <string name="main.songs_starred">@string/main.albums_starred</string>
 	<string name="main.songs_genres">@string/main.albums_genres</string>
 	<string name="main.songs_newest">@string/main.albums_newest</string>
 	<string name="main.songs_top_played">Top Played</string>


### PR DESCRIPTION
# Motivation
Sometimes you just want to focus on your favorite ("starred") songs,  
but DSub2000 currently mixes albums and songs together.  
This makes it harder to browse or play just what you want.

<img width="427" height="825" alt="grafik" src="https://github.com/user-attachments/assets/90abeb5d-e056-4ed4-94f2-16e1ab0af116" />


# What changed
- "Starred" is now split into **Albums** and **Songs** for a clearer view.  
- Introduced **StarredRepository** to handle the API response, which includes both albums and songs.  
- **StarredRepository** filters the data so only the relevant type is shown.  
- Both `SelectDirectoryFragment` and `SubsonicFragment` now use **StarredRepository**.