### PR TITLE
Improvements to Random Songs Feature, Options Menu, and Initial Song Loading

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/adapter/EntryInfiniteGridAdapter.java
+++ b/app/src/main/java/github/paroj/dsub2000/adapter/EntryInfiniteGridAdapter.java
@@ -90,7 +90,7 @@ public class EntryInfiniteGridAdapter extends EntryGridAdapter {
 		this.extra = extra;
 		this.size = size;
 
-		if(super.getItemCount() < size) {
+		if(super.getItemCount() < size && !"randomsongs".equals(type)) {
 			allLoaded = true;
 		}
 	}

--- a/app/src/main/java/github/paroj/dsub2000/fragments/SelectDirectoryFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/SelectDirectoryFragment.java
@@ -227,7 +227,7 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 	public void onCreateOptionsMenu(Menu menu, MenuInflater menuInflater) {
 		if(licenseValid == null) {
 			menuInflater.inflate(R.menu.empty, menu);
-		} else if(albumListType != null && !albumListType.startsWith("starred")) {
+		} else if(albumListType != null && !albumListType.startsWith("starred") && !albumListType.startsWith("random")) {
 			menuInflater.inflate(R.menu.select_album_list, menu);
 		} else if(artist && !showAll) {
 			menuInflater.inflate(R.menu.select_album, menu);
@@ -261,6 +261,12 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 				if(!prefs.getBoolean(Constants.PREFERENCES_KEY_MENU_PLAY_LAST, true)) {
 					menu.setGroupVisible(R.id.hide_play_last, false);
 				}
+
+                if (albumListType.startsWith("random")) {
+                    menu.removeItem(R.id.menu_download);
+                    menu.removeItem(R.id.menu_cache);
+                    menu.removeItem(R.id.menu_delete);
+                }
 			} else {
 				if(Util.isOffline(context)) {
 					menuInflater.inflate(R.menu.select_podcast_episode_offline, menu);
@@ -362,7 +368,7 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 
 			onSongPress(Arrays.asList(entry), entry, false);
 		} else {
-			onSongPress(entries, entry, albumListType == null || "starredsongs".equals(albumListType));
+			onSongPress(entries, entry, albumListType == null || "starredsongs".equals(albumListType) || "randomsongs".equals(albumListType));
 		}
 	}
 
@@ -585,7 +591,10 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 				} else if("genres".equals(albumListType) || "genres-songs".equals(albumListType)) {
 					result = service.getSongsByGenre(albumListExtra, size, 0, context, this);
 				} else if("randomsongs".equals(albumListType)) {
-					result = service.getRandomSongs(size,context, this);
+                    // Get users desired random playlist size
+                    SharedPreferences prefs = Util.getPreferences(context);
+                    int listSize = Math.max(1, Integer.parseInt(prefs.getString(Constants.PREFERENCES_KEY_RANDOM_SIZE, "20")));
+					result = service.getRandomSongs(listSize,context, this);
 				}  else if(albumListType.indexOf(MainFragment.SONGS_LIST_PREFIX) != -1) {
 					result = service.getSongList(albumListType, size, 0, context, this);
 				} else {

--- a/app/src/main/res/xml/settings_playback.xml
+++ b/app/src/main/res/xml/settings_playback.xml
@@ -11,7 +11,8 @@
 			android:key="randomSize"
 			android:defaultValue="20"
 			android:dialogLayout="@layout/seekbar_preference"
-			myns:max="100"/>
+            myns:min="5"
+			myns:max="200"/>
 
 		<ListPreference
 			android:title="@string/settings.keep_played_count_title"


### PR DESCRIPTION
## Updates

### 1. Random Songs Playback Fixes
When selecting a single song from the **Random Songs** list:
- Only the selected song was played, and the rest of the playlist was missing.
- Seek buttons were shown instead of the usual next/previous track buttons.

These issues have been fixed so that playback from the random songs list behaves like a proper playlist.

### 2. Options Menu Improvements
The options menu (three dots in the top-right corner) previously only showed an **"Exit"** option.  
It now shows the actions:
- Play Next  
- Play Last  

This improvement applies to:
- Random songs 
- Random albums  

### 3. Improved Initial Loading of Random Songs
When opening the **Random Songs** list:
- The initial number of songs now respects the **"Shuffle Playlist Size"** setting.
- Infinite scrolling continues to work and loads **20 more songs** each time.
- 
### 4. Updated "Shuffle Playlist Size" Range
The configurable range for **Shuffle Playlist Size** has been updated:
- **Old:** 0–100  
- **New:** 5–200  

This provides a more practical minimum and allows larger random lists.