### PR TITLE
Add configurable Action Bar colors (separate for Main & Now Playing)

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/activity/SettingsActivity.java
+++ b/app/src/main/java/github/paroj/dsub2000/activity/SettingsActivity.java
@@ -19,6 +19,7 @@
 package github.paroj.dsub2000.activity;
 
 import android.annotation.TargetApi;
+import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Bundle;
 import androidx.appcompat.widget.Toolbar;
@@ -27,6 +28,7 @@ import github.paroj.dsub2000.R;
 import github.paroj.dsub2000.fragments.PreferenceCompatFragment;
 import github.paroj.dsub2000.fragments.SettingsFragment;
 import github.paroj.dsub2000.util.Constants;
+import github.paroj.dsub2000.util.Util;
 
 public class SettingsActivity extends SubsonicActivity {
 	private static final String TAG = SettingsActivity.class.getSimpleName();
@@ -53,6 +55,13 @@ public class SettingsActivity extends SubsonicActivity {
 		}
 
 		Toolbar mainToolbar = (Toolbar) findViewById(R.id.main_toolbar);
-		setSupportActionBar(mainToolbar);
+        SharedPreferences prefs = Util.getPreferences(this);
+        if (prefs.getBoolean(Constants.PREFERENCES_KEY_COLOR_ACTION_BAR, true)) {
+            int color = prefs.getInt(Constants.PREFERENCES_KEY_ACTION_BAR_COLOR, -1);
+            if (color != -1) {
+                mainToolbar.setBackgroundColor(color);
+            }
+        }
+        setSupportActionBar(mainToolbar);
 	}
 }

--- a/app/src/main/java/github/paroj/dsub2000/activity/SubsonicActivity.java
+++ b/app/src/main/java/github/paroj/dsub2000/activity/SubsonicActivity.java
@@ -94,6 +94,8 @@ public class SubsonicActivity extends AppCompatActivity implements OnItemSelecte
 	protected static String theme;
 	protected static boolean fullScreen;
 	protected static boolean actionbarColored;
+    protected static int actionbarCustomColor;
+    protected static int actionbarNowPlayingCustomColor;
 	private static final int MENU_GROUP_SERVER = 10;
 	private static final int MENU_ITEM_SERVER_BASE = 100;
 	public static final int PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE = 1;
@@ -280,13 +282,20 @@ public class SubsonicActivity extends AppCompatActivity implements OnItemSelecte
 		Util.registerMediaButtonEventReceiver(this);
 
 		// Make sure to update theme
-		SharedPreferences prefs = Util.getPreferences(this);
-		if (theme != null && !theme.equals(ThemeUtil.getTheme(this)) || fullScreen != prefs.getBoolean(Constants.PREFERENCES_KEY_FULL_SCREEN, false) || actionbarColored != prefs.getBoolean(Constants.PREFERENCES_KEY_COLOR_ACTION_BAR, true)) {
-			restart();
-			overridePendingTransition(R.anim.fade_in, R.anim.fade_out);
-			DrawableTint.clearCache();
-			return;
-		}
+		if (theme != null) {
+            SharedPreferences prefs = Util.getPreferences(this);
+            boolean isThemeUpdated = !theme.equals(ThemeUtil.getTheme(this));
+            boolean isFullScreenUpdated = fullScreen != prefs.getBoolean(Constants.PREFERENCES_KEY_FULL_SCREEN, false);
+            boolean isActionBarColoredUpdated = actionbarColored != prefs.getBoolean(Constants.PREFERENCES_KEY_COLOR_ACTION_BAR, true);
+            boolean isActionBarCustomColorUpdated = actionbarCustomColor != prefs.getInt(Constants.PREFERENCES_KEY_ACTION_BAR_COLOR, -1);
+            boolean isActionBarNowPlayingCustomColorUpdated = actionbarNowPlayingCustomColor != prefs.getInt(Constants.PREFERENCES_KEY_ACTION_BAR_NOW_PLAYING_COLOR, -1);
+            if (isThemeUpdated || isFullScreenUpdated || isActionBarColoredUpdated || isActionBarCustomColorUpdated || isActionBarNowPlayingCustomColorUpdated) {
+                restart();
+                overridePendingTransition(R.anim.fade_in, R.anim.fade_out);
+                DrawableTint.clearCache();
+                return;
+            }
+        }
 
 		getImageLoader().onUIVisible();
 		UpdateView.addActiveActivity();
@@ -988,7 +997,10 @@ public class SubsonicActivity extends AppCompatActivity implements OnItemSelecte
 		}
 
 		ThemeUtil.applyTheme(this, theme);
-		actionbarColored = Util.getPreferences(this).getBoolean(Constants.PREFERENCES_KEY_COLOR_ACTION_BAR, true);
+        SharedPreferences prefs = Util.getPreferences(this);
+		actionbarColored = prefs.getBoolean(Constants.PREFERENCES_KEY_COLOR_ACTION_BAR, true);
+        actionbarCustomColor = prefs.getInt(Constants.PREFERENCES_KEY_ACTION_BAR_COLOR, -1);
+        actionbarNowPlayingCustomColor = prefs.getInt(Constants.PREFERENCES_KEY_ACTION_BAR_NOW_PLAYING_COLOR, -1);
 	}
 	private void applyFullscreen() {
 		fullScreen = Util.getPreferences(this).getBoolean(Constants.PREFERENCES_KEY_FULL_SCREEN, false);

--- a/app/src/main/java/github/paroj/dsub2000/activity/SubsonicFragmentActivity.java
+++ b/app/src/main/java/github/paroj/dsub2000/activity/SubsonicFragmentActivity.java
@@ -39,6 +39,7 @@ import androidx.appcompat.widget.Toolbar;
 import android.util.Log;
 import android.view.MenuItem;
 import android.view.View;
+import android.widget.FrameLayout;
 import android.widget.ImageButton;
 import android.widget.ImageView;
 import android.widget.TextView;
@@ -98,7 +99,7 @@ public class SubsonicFragmentActivity extends SubsonicActivity implements Downlo
 	private SubsonicFragment secondaryFragment;
 	private Toolbar mainToolbar;
 	private Toolbar nowPlayingToolbar;
-
+    private FrameLayout slideUpSwipeTarget;
 	private View bottomBar;
 	private ImageView coverArtView;
 	private TextView trackView;
@@ -278,7 +279,20 @@ public class SubsonicFragmentActivity extends SubsonicActivity implements Downlo
 		coverArtView = (ImageView) bottomBar.findViewById(R.id.album_art);
 		trackView = (TextView) bottomBar.findViewById(R.id.track_name);
 		artistView = (TextView) bottomBar.findViewById(R.id.artist_name);
+        slideUpSwipeTarget = (FrameLayout) findViewById(R.id.slide_up_swipe_target);
 
+        SharedPreferences prefs = Util.getPreferences(this);
+        if (prefs.getBoolean(Constants.PREFERENCES_KEY_COLOR_ACTION_BAR, true)) {
+            int mainToolbarColor = prefs.getInt(Constants.PREFERENCES_KEY_ACTION_BAR_COLOR, -1);
+            if (mainToolbarColor != -1) {
+                mainToolbar.setBackgroundColor(mainToolbarColor);
+            }
+            int nowPlayingToolbarColor = prefs.getInt(Constants.PREFERENCES_KEY_ACTION_BAR_NOW_PLAYING_COLOR, -1);
+            if (nowPlayingToolbarColor != -1) {
+                nowPlayingToolbar.setBackgroundColor(nowPlayingToolbarColor);
+                slideUpSwipeTarget.setBackgroundColor(nowPlayingToolbarColor);
+            }
+        }
 		setSupportActionBar(mainToolbar);
 
 		if (findViewById(R.id.fragment_container) != null && savedInstanceState == null) {

--- a/app/src/main/java/github/paroj/dsub2000/fragments/SettingsFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/SettingsFragment.java
@@ -23,6 +23,8 @@ import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.pm.PackageManager;
+import android.graphics.Color;
+import android.graphics.drawable.GradientDrawable;
 import android.net.Uri;
 import android.os.Build;
 import android.os.Bundle;
@@ -63,6 +65,7 @@ import github.paroj.dsub2000.util.SyncUtil;
 import github.paroj.dsub2000.util.Util;
 import github.paroj.dsub2000.util.compat.GoogleCompat;
 import github.paroj.dsub2000.view.CacheLocationPreference;
+import github.paroj.dsub2000.view.ColorPickerPreference;
 import github.paroj.dsub2000.view.ErrorDialog;
 import github.paroj.dsub2000.view.EditPasswordPreference;
 
@@ -72,6 +75,9 @@ public class SettingsFragment extends PreferenceCompatFragment implements Shared
 	private final Map<String, ServerSettings> serverSettings = new LinkedHashMap<String, ServerSettings>();
 	private boolean testingConnection;
 	private ListPreference theme;
+    private CheckBoxPreference colorActionBar;
+    private ColorPickerPreference actionBarColor;
+    private ColorPickerPreference actionBarColorNowPlaying;
 	private ListPreference maxBitrateWifi;
 	private ListPreference maxBitrateMobile;
 	private ListPreference maxVideoBitrateWifi;
@@ -210,6 +216,12 @@ public class SettingsFragment extends PreferenceCompatFragment implements Shared
 					ActivityCompat.requestPermissions(context, new String[]{ Manifest.permission.ACCESS_COARSE_LOCATION }, SubsonicActivity.PERMISSIONS_REQUEST_LOCATION);
 				}
 			}
+            if (actionBarColor != null && actionBarColorNowPlaying != null) {
+                setColorIcon(actionBarColor, -1);
+                setColorIcon(actionBarColorNowPlaying, -1);
+                sharedPreferences.edit().putInt(Constants.PREFERENCES_KEY_ACTION_BAR_COLOR, -1).commit();
+                sharedPreferences.edit().putInt(Constants.PREFERENCES_KEY_ACTION_BAR_NOW_PLAYING_COLOR, -1).commit();
+            }
 		} else if(Constants.PREFERENCES_KEY_DLNA_CASTING_ENABLED.equals(key)) {
 			DownloadService downloadService = DownloadService.getInstance();
 			if(downloadService != null) {
@@ -222,7 +234,23 @@ public class SettingsFragment extends PreferenceCompatFragment implements Shared
 					mediaRouter.removeDLNAProvider();
 				}
 			}
-		}
+        } else if (Constants.PREFERENCES_KEY_COLOR_ACTION_BAR.equals(key)) {
+            if (actionBarColor != null && actionBarColorNowPlaying != null) {
+                boolean isActionBarColored = sharedPreferences.getBoolean(key, true);
+                actionBarColor.setEnabled(isActionBarColored);
+                actionBarColorNowPlaying.setEnabled(isActionBarColored);
+            }
+        } else if (Constants.PREFERENCES_KEY_ACTION_BAR_COLOR.equals(key)) {
+            if (actionBarColor != null) {
+                int color = sharedPreferences.getInt(key, -1);
+                setColorIcon(actionBarColor, color);
+            }
+        } else if (Constants.PREFERENCES_KEY_ACTION_BAR_NOW_PLAYING_COLOR.equals(key)) {
+            if (actionBarColorNowPlaying != null) {
+                int color = sharedPreferences.getInt(key, -1);
+                setColorIcon(actionBarColorNowPlaying, color);
+            }
+        }
 
 		scheduleBackup();
 	}
@@ -265,6 +293,9 @@ public class SettingsFragment extends PreferenceCompatFragment implements Shared
 		replayGainUntagged = this.findPreference(Constants.PREFERENCES_KEY_REPLAY_GAIN_UNTAGGED);
 		cacheSize = (EditTextPreference) this.findPreference(Constants.PREFERENCES_KEY_CACHE_SIZE);
 		openToTab = (ListPreference) this.findPreference(Constants.PREFERENCES_KEY_OPEN_TO_TAB);
+        colorActionBar = (CheckBoxPreference) this.findPreference(Constants.PREFERENCES_KEY_COLOR_ACTION_BAR);
+        actionBarColor = (ColorPickerPreference) this.findPreference(Constants.PREFERENCES_KEY_ACTION_BAR_COLOR);
+        actionBarColorNowPlaying = (ColorPickerPreference) this.findPreference(Constants.PREFERENCES_KEY_ACTION_BAR_NOW_PLAYING_COLOR);
 
 		settings = Util.getPreferences(context);
 		serverCount = settings.getInt(Constants.PREFERENCES_KEY_SERVER_COUNT, 1);
@@ -369,6 +400,17 @@ public class SettingsFragment extends PreferenceCompatFragment implements Shared
 
 		SharedPreferences prefs = Util.getPreferences(context);
 		prefs.registerOnSharedPreferenceChangeListener(this);
+
+        if (actionBarColor != null && actionBarColorNowPlaying != null) {
+            boolean isActionBarColored = prefs.getBoolean(Constants.PREFERENCES_KEY_COLOR_ACTION_BAR, true);
+            actionBarColor.setEnabled(isActionBarColored);
+            actionBarColorNowPlaying.setEnabled(isActionBarColored);
+
+            int actionBarColorInt = prefs.getInt(Constants.PREFERENCES_KEY_ACTION_BAR_COLOR, -1);
+            int actionBarColorNowPlayingInt = prefs.getInt(Constants.PREFERENCES_KEY_ACTION_BAR_NOW_PLAYING_COLOR, -1);
+            setColorIcon(actionBarColor, actionBarColorInt);
+            setColorIcon(actionBarColorNowPlaying, actionBarColorNowPlayingInt);
+        }
 
 		update();
 	}
@@ -475,6 +517,24 @@ public class SettingsFragment extends PreferenceCompatFragment implements Shared
 			}
 		}
 	}
+
+    private void setColorIcon(Preference preference, int color) {
+        if (color == -1) {
+            preference.setIcon(null);
+        } else {
+            int sizeDp = 24;
+            float scale = getResources().getDisplayMetrics().density;
+            int sizePx = (int) (sizeDp * scale + 0.5f);
+
+            GradientDrawable drawable = new GradientDrawable();
+            drawable.setShape(GradientDrawable.RECTANGLE);
+            drawable.setColor(color);
+            drawable.setCornerRadius(6f);
+            drawable.setSize(sizePx, sizePx);
+            drawable.setStroke(2, Color.DKGRAY);
+            preference.setIcon(drawable);
+        }
+    }
 
 	private PreferenceScreen addServer(final int instance) {
 		final PreferenceScreen screen = this.getPreferenceManager().createPreferenceScreen(context);

--- a/app/src/main/java/github/paroj/dsub2000/util/Constants.java
+++ b/app/src/main/java/github/paroj/dsub2000/util/Constants.java
@@ -178,6 +178,8 @@ public final class Constants {
 	public static final String PREFERENCES_KEY_FIRST_LEVEL_ARTIST = "firstLevelArtist";
 	public static final String PREFERENCES_KEY_START_ON_HEADPHONES = "startOnHeadphones";
 	public static final String PREFERENCES_KEY_COLOR_ACTION_BAR = "colorActionBar";
+    public static final String PREFERENCES_KEY_ACTION_BAR_COLOR = "actionBarColor";
+    public static final String PREFERENCES_KEY_ACTION_BAR_NOW_PLAYING_COLOR = "actionBarColorNowPlaying";
 	public static final String PREFERENCES_KEY_SHUFFLE_BY_ALBUM = "shuffleByAlbum";
 	public static final String PREFERENCES_KEY_RESUME_PLAY_QUEUE_NEVER = "neverResumePlayQueue";
 	public static final String PREFERENCES_KEY_BATCH_MODE = "batchMode";

--- a/app/src/main/java/github/paroj/dsub2000/util/DrawableTint.java
+++ b/app/src/main/java/github/paroj/dsub2000/util/DrawableTint.java
@@ -74,6 +74,13 @@ public class DrawableTint {
 
 		return color;
 	}
+    public static int getColorRes(Context context, @AttrRes int colorAttr, @AttrRes int themeResId) {
+        TypedValue typedValue = new TypedValue();
+        Resources.Theme theme = context.getTheme();
+        theme.applyStyle(themeResId, true);
+        theme.resolveAttribute(colorAttr, typedValue, true);
+        return typedValue.data;
+    }
 	public static int getDrawableRes(Context context, @AttrRes int drawableAttr) {
 		if(attrMap.containsKey(drawableAttr)) {
 			return attrMap.get(drawableAttr);

--- a/app/src/main/java/github/paroj/dsub2000/view/ColorPickerPreference.java
+++ b/app/src/main/java/github/paroj/dsub2000/view/ColorPickerPreference.java
@@ -1,0 +1,184 @@
+package github.paroj.dsub2000.view;
+
+import android.content.SharedPreferences;
+import android.graphics.drawable.GradientDrawable;
+import android.preference.DialogPreference;
+import android.content.Context;
+import android.graphics.Color;
+import android.util.AttributeSet;
+import android.view.ContextThemeWrapper;
+import android.view.View;
+import android.widget.Button;
+import android.widget.SeekBar;
+
+import androidx.core.graphics.ColorUtils;
+
+import github.paroj.dsub2000.R;
+import github.paroj.dsub2000.util.Constants;
+import github.paroj.dsub2000.util.DrawableTint;
+import github.paroj.dsub2000.util.ThemeUtil;
+import github.paroj.dsub2000.util.Util;
+
+public class ColorPickerPreference extends DialogPreference {
+    private static final String TAG = ColorPickerPreference.class.getSimpleName();
+    private SeekBar seekHue;
+    private SeekBar seekSat;
+    private SeekBar seekLight;
+    private View preview;
+    private float hue, sat, light; // 0..359 / 0..1 / 0..1
+    private int mValue;
+    private boolean isColorReset;
+    private boolean isUntouched;
+    private Context mContext;
+    private final int initialThemeRes;
+    private final SharedPreferences prefs;
+
+    public ColorPickerPreference(Context context, AttributeSet attrs) {
+        super(context, attrs);
+        mContext = context;
+        setDialogLayoutResource(R.layout.dialog_color_picker);
+        setPositiveButtonText(android.R.string.ok);
+        setNegativeButtonText(android.R.string.cancel);
+        setDialogTitle(R.string.color_picker_title);
+        initialThemeRes = ThemeUtil.getThemeRes(mContext);
+        prefs = Util.getPreferences(mContext);
+        isColorReset = false;
+        isUntouched = true;
+    }
+
+    @Override
+    protected View onCreateDialogView()
+    {
+        View view = super.onCreateDialogView();
+
+        // Ensure the ColorPicker uses the initial theme,
+        // since reopening it after a theme change can apply the new theme unexpectedly.
+        String storedTheme = prefs.getString(Constants.PREFERENCES_KEY_THEME, null);
+        int storedThemRes = ThemeUtil.getThemeRes(mContext, storedTheme);
+        if (storedThemRes != initialThemeRes) {
+            mContext = new ContextThemeWrapper(mContext, initialThemeRes);
+        }
+
+        int persistedColor = getPersistedInt(-1);
+        if (persistedColor == -1) {
+            mValue = getThemeDefaultColor();
+        } else {
+            mValue = persistedColor;
+        }
+
+        updateHSLFromInt(mValue);
+        seekHue = view.findViewById(R.id.hueSlider);
+        seekSat = view.findViewById(R.id.satSlider);
+        seekLight = view.findViewById(R.id.lightSlider);
+        preview = view.findViewById(R.id.colorPreview);
+        Button buttonReset = view.findViewById(R.id.button_reset);
+
+        seekHue.setProgress((int) hue);
+        seekSat.setProgress((int) (sat * 100));
+        seekLight.setProgress((int) (light * 100));
+
+        final Runnable updatePreview = new Runnable() {
+            @Override
+            public void run() {
+                isColorReset = false;
+                isUntouched = false;
+                setColor();
+            }
+        };
+
+        seekHue.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+            @Override
+            public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+                updatePreview.run();
+            }
+
+            @Override
+            public void onStartTrackingTouch(SeekBar seekBar) {}
+
+            @Override
+            public void onStopTrackingTouch(SeekBar seekBar) {}
+        });
+
+        seekSat.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+            @Override
+            public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+                updatePreview.run();
+            }
+
+            @Override
+            public void onStartTrackingTouch(SeekBar seekBar) {}
+
+            @Override
+            public void onStopTrackingTouch(SeekBar seekBar) {}
+        });
+
+        seekLight.setOnSeekBarChangeListener(new SeekBar.OnSeekBarChangeListener() {
+            @Override
+            public void onProgressChanged(SeekBar seekBar, int progress, boolean fromUser) {
+                updatePreview.run();
+            }
+
+            @Override
+            public void onStartTrackingTouch(SeekBar seekBar) {}
+
+            @Override
+            public void onStopTrackingTouch(SeekBar seekBar) {}
+        });
+
+        buttonReset.setOnClickListener(v -> {
+            mValue = getThemeDefaultColor();
+            updateHSLFromInt(mValue);
+            seekHue.setProgress((int) hue);
+            seekSat.setProgress((int) (sat * 100));
+            seekLight.setProgress((int) (light * 100));
+            isColorReset = true;
+        });
+
+        setColor();
+
+        return view;
+    }
+
+    @Override
+    protected void onDialogClosed(boolean positiveResult)
+    {
+        if(positiveResult) {
+            if (isColorReset || isUntouched) {
+                persistInt(-1);
+            } else {
+                persistInt(mValue);
+            }
+            notifyChanged();
+        }
+    }
+
+    private void setColor() {
+        float hue = seekHue.getProgress();
+        float sat = seekSat.getProgress() / 100f;
+        float light = seekLight.getProgress() / 100f;
+        float[] hsl = new float[]{hue, sat, light};
+        mValue = ColorUtils.HSLToColor(hsl);
+        GradientDrawable bg = (GradientDrawable) preview.getBackground();
+        bg.setColor(mValue);
+    }
+
+    private void updateHSLFromInt(int value) {
+        float[] hsl = new float[3];
+        ColorUtils.RGBToHSL(Color.red(value), Color.green(value), Color.blue(value), hsl);
+        hue = hsl[0];
+        sat = hsl[1];
+        light = hsl[2];
+    }
+
+    private int getThemeDefaultColor() {
+        String key = getKey();
+        String theme = prefs.getString(Constants.PREFERENCES_KEY_THEME, null);
+        int themeResId = ThemeUtil.getThemeRes(mContext, theme);
+        if ("actionBarColorNowPlaying".equals(key)) {
+            return DrawableTint.getColorRes(mContext, R.attr.colorPrimaryDark, themeResId);
+        } else {
+            return DrawableTint.getColorRes(mContext, R.attr.colorPrimary, themeResId);
+        }
+    }
+
+}

--- a/app/src/main/res/drawable/color_preview.xml
+++ b/app/src/main/res/drawable/color_preview.xml
@@ -1,0 +1,7 @@
+<shape xmlns:android="http://schemas.android.com/apk/res/android"
+    android:shape="oval">
+    <solid android:color="#FF0000"/>
+    <stroke
+        android:width="4dp"
+        android:color="#FF888888"/>
+</shape>

--- a/app/src/main/res/layout/abstract_fragment_activity.xml
+++ b/app/src/main/res/layout/abstract_fragment_activity.xml
@@ -36,7 +36,7 @@
 			android:id="@+id/slide_up_swipe_target"
 			android:layout_width="match_parent"
 			android:layout_height="wrap_content"
-			android:background="?attr/actionbarBackgroundColor">
+			android:background="?attr/actionbarNowPlayingBackgroundColor">
 
 			<androidx.appcompat.widget.Toolbar
 				android:id="@+id/now_playing_toolbar"

--- a/app/src/main/res/layout/dialog_color_picker.xml
+++ b/app/src/main/res/layout/dialog_color_picker.xml
@@ -1,0 +1,68 @@
+<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
+    android:orientation="vertical"
+    android:padding="20dp"
+    android:layout_width="match_parent"
+    android:layout_height="wrap_content">
+
+    <View
+        android:id="@+id/colorPreview"
+        android:layout_width="150dp"
+        android:layout_height="150dp"
+        android:layout_gravity="center_horizontal"
+        android:background="@drawable/color_preview"/>
+
+    <TextView
+        android:text="@string/color_picker.hue"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="20dp"/>
+
+    <SeekBar
+        android:id="@+id/hueSlider"
+        android:max="359"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+    <!-- max 359. Set because HSL Hue is cyclic (360° = 0°),
+    preventing redundant values. -->
+
+    <TextView
+        android:text="@string/color_picker.saturation"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"/>
+
+    <SeekBar
+        android:id="@+id/satSlider"
+        android:max="100"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+
+    <TextView
+        android:text="@string/color_picker.lightness"
+        android:layout_width="wrap_content"
+        android:layout_height="wrap_content"
+        android:layout_marginTop="10dp"/>
+
+    <SeekBar
+        android:id="@+id/lightSlider"
+        android:max="95"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"/>
+    <!-- max 95 ensures contrast/readability as L=100% is pure white,
+         causing white-on-white text issues. -->
+
+    <LinearLayout
+        android:orientation="horizontal"
+        android:layout_width="match_parent"
+        android:layout_height="wrap_content"
+        android:gravity="center"
+        android:layout_marginTop="20dp">
+
+        <Button
+            android:id="@+id/button_reset"
+            android:text="@string/common.reset"
+            android:layout_width="wrap_content"
+            android:layout_height="wrap_content"/>
+    </LinearLayout>
+
+</LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -628,10 +628,17 @@
 	<string name="common.false">Nein</string>
 	<string name="settings.menu_options.play_now_summary">Zeige \"Jetzt wiedergeben\" im Menü</string>
 	<string name="settings.menu_options.play_shuffled_summary">Zeige \"Mischen\" im Menü</string>
+    <string name="settings.color_action_bar">Bedienleiste einfärben</string>
+    <string name="settings.color_action_bar.summary">Die Bedienleiste und die Statusleiste einfärben oder unverändert lassen</string>
+    <string name="settings.general_action_bar_color">Farbe allgemeine Bedienleiste</string>
+    <string name="settings.general_action_bar_color_summary">Wähle die Farbe für die allgemeine Bedienleiste</string>
+    <string name="settings.now_playing_action_bar_color">Farbe Bedienleiste „Aktuelle Wiedergabe“</string>
+    <string name="settings.now_playing_action_bar_color_summary">Wähle die Farbe der Bedienleiste im „Aktuelle Wiedergabe“-Bildschirm</string>
 	<string name="settings.shuffle_by_album.false">Alle Titel mischen</string>
 	<string name="settings.shuffle_by_album.true">Albenreihenfolge mischen</string>
 	<string name="settings.shuffle_by_album">Alben mischen</string>
 	<string name="common.never">Nie</string>
+    <string name="common.reset">Zurücksetzen</string>
 	<string name="details.starred">Favorit</string>
 	<string name="download.thumbs_up">Gefällt mir</string>
 	<string name="download.thumbs_down">Gefällt mir nicht</string>
@@ -658,5 +665,8 @@
 	<string name="settings.tap_cover_for_playlist_summary">Zeige die aktuelle Wiedergabeliste wenn auf das Albumcover getippt wird</string>
 	<string name="settings.combine_thumbs_up_down">Bewertungsknöpfe zusammenfassen</string>
 	<string name="settings.combine_thumbs_up_down_summary">Vereint die \"Daumen hoch\" und \"Daumen runter\" Knöpfe zu einem Knopf, welcher einen Bewertungsdialog öffnet</string>
-
+    <string name="color_picker.title">Wähle eine Farbe</string>
+    <string name="color_picker.hue">Farbton</string>
+    <string name="color_picker.saturation">Sättigung</string>
+    <string name="color_picker.lightness">Helligkeit</string>
 </resources>

--- a/app/src/main/res/values/attrs.xml
+++ b/app/src/main/res/values/attrs.xml
@@ -64,6 +64,7 @@
 	<attr name="actionbarSubtitleStyle" format="reference"/>
 	<attr name="actionbarPopupStyle" format="reference"/>
 	<attr name="actionbarBackgroundColor" format="reference"/>
+    <attr name="actionbarNowPlayingBackgroundColor" format="reference"/>
 	<attr name="drawerTitleStyle" format="reference"/>
 	<attr name="drawerSubtitleStyle" format="reference"/>
 	<attr name="cardBackgroundDrawable" format="reference"/>

--- a/app/src/main/res/values/colors.xml
+++ b/app/src/main/res/values/colors.xml
@@ -9,13 +9,13 @@
 	<color name="holo_red_light">#ffff4444</color>
 
 	<color name="lightPrimary">#2196f3</color>
-	<color name="lightPrimaryDark">#1e88e5</color>
+	<color name="lightPrimaryDark">#0d47a1</color>
 	<color name="lightAccent">#448aff</color>
 	<color name="lightElement">#A0000000</color>
 
 
 	<color name="holoPrimary">#009688</color>
-	<color name="holoPrimaryDark">#00897b</color>
+	<color name="holoPrimaryDark">#003c36</color>
 	<color name="holoAccent">#64ffda</color>
 
 	<color name="darkElement">#F8F8F8</color>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -29,6 +29,7 @@
 	<string name="common.false">No</string>
 	<string name="common.true">Yes</string>
 	<string name="common.never">Never</string>
+    <string name="common.reset">Reset</string>
 
     <string name="button_bar.home">Home</string>
     <string name="button_bar.browse">Library</string>
@@ -488,6 +489,10 @@
 	<string name="settings.start_on_headphones_summary">Start when headphones are plugged in.  This requires the use of a service which starts on boot up to check for the headphone plug event even when DSub2000 is not running.</string>
 	<string name="settings.color_action_bar">Color Action Bar</string>
 	<string name="settings.color_action_bar.summary">Color the action bar and status bar or leave them alone</string>
+    <string name="settings.general_action_bar_color">General Action Bar Color</string>
+    <string name="settings.general_action_bar_color_summary">Choose a color for the general action bar</string>
+    <string name="settings.now_playing_action_bar_color">Now Playing Action Bar Color</string>
+    <string name="settings.now_playing_action_bar_color_summary">Choose a color for the action bar in the Now Playing screen</string>
 	<string name="settings.shuffle_by_album">Shuffle By Album</string>
 	<string name="settings.shuffle_by_album.true">Shuffle order of albums</string>
 	<string name="settings.shuffle_by_album.false">Shuffle all songs together</string>
@@ -703,4 +708,8 @@
 	<string name="settings.combine_thumbs_up_down">Combine rating buttons</string>
 	<string name="settings.combine_thumbs_up_down_summary">Merge the thumbs up and thumbs down buttons into one single button that opens a rating dialog</string>
 
+    <string name="color_picker.title">Select a Color</string>
+    <string name="color_picker.hue">Hue</string>
+    <string name="color_picker.saturation">Saturation</string>
+    <string name="color_picker.lightness">Lightness</string>
 </resources>

--- a/app/src/main/res/values/themes.xml
+++ b/app/src/main/res/values/themes.xml
@@ -62,6 +62,7 @@
 		<item name="colorPrimaryDark">@color/lightPrimaryDark</item>
 		<item name="colorAccent">@color/lightAccent</item>
 		<item name="actionbarBackgroundColor">@color/lightPrimary</item>
+        <item name="actionbarNowPlayingBackgroundColor">@color/lightPrimaryDark</item>
 		<item name="actionbarTitleStyle">@style/TextAppearance.AppCompat.Widget.ActionBar.Title.Inverse</item>
 		<item name="actionbarSubtitleStyle">@style/TextAppearance.AppCompat.Widget.ActionBar.Subtitle.Inverse</item>
 		<item name="actionbarPopupStyle">@style/ThemeOverlay.AppCompat.Light</item>
@@ -137,6 +138,7 @@
 		<item name="colorPrimaryDark">@color/lightPrimaryDark</item>
 		<item name="colorAccent">@color/lightAccent</item>
 		<item name="actionbarBackgroundColor">@color/lightPrimary</item>
+        <item name="actionbarNowPlayingBackgroundColor">@color/lightPrimaryDark</item>
 		<item name="actionbarTitleStyle">@style/TextAppearance.AppCompat.Widget.ActionBar.Title</item>
 		<item name="actionbarSubtitleStyle">@style/TextAppearance.AppCompat.Widget.ActionBar.Subtitle</item>
 		<item name="actionbarPopupStyle">@style/ThemeOverlay.AppCompat.Dark</item>
@@ -166,6 +168,7 @@
 		<item name="colorPrimaryDark">@color/holoPrimaryDark</item>
 		<item name="colorAccent">@color/holoAccent</item>
 		<item name="actionbarBackgroundColor">@color/holoPrimary</item>
+        <item name="actionbarNowPlayingBackgroundColor">@color/holoPrimaryDark</item>
 		<item name="drawerHeaderBackground">@drawable/drawer_header_holo</item>
 		<item name="card_background">@color/background_material_dark</item>
 		<item name="cardBackgroundDrawable">@drawable/card_rounded_corners</item>
@@ -194,6 +197,7 @@
 		<item name="actionbar_element_color">@color/lightElement</item>
 		<item name="actionbarThemeStyle">@style/ThemeOverlay.AppCompat.ActionBar</item>
 		<item name="actionbarBackgroundColor">@android:color/transparent</item>
+        <item name="actionbarNowPlayingBackgroundColor">@android:color/transparent</item>
 		<item name="actionbarTitleStyle">@style/TextAppearance.AppCompat.Widget.ActionBar.Title</item>
 		<item name="actionbarSubtitleStyle">@style/TextAppearance.AppCompat.Widget.ActionBar.Subtitle</item>
 		<item name="android:spinnerItemStyle">@style/LightSpinnerItem</item>
@@ -221,14 +225,17 @@
 	</style>
 	<style name="Theme.DSub2000.Black.No_Color.Base" parent="Theme.DSub2000.Black.No_Actionbar">
 		<item name="actionbarBackgroundColor">@android:color/transparent</item>
+        <item name="actionbarNowPlayingBackgroundColor">@android:color/transparent</item>
 		<item name="actionModeBackground">@android:color/black</item>
 	</style>
 	<style name="Theme.DSub2000.Dark.No_Color.Base" parent="Theme.DSub2000.Dark.No_Actionbar">
 		<item name="actionbarBackgroundColor">@android:color/transparent</item>
+        <item name="actionbarNowPlayingBackgroundColor">@android:color/transparent</item>
 		<item name="actionModeBackground">@color/background_material_dark</item>
 	</style>
 	<style name="Theme.DSub2000.Holo.No_Color.Base" parent="Theme.DSub2000.Holo.No_Actionbar">
 		<item name="actionbarBackgroundColor">@android:color/transparent</item>
+        <item name="actionbarNowPlayingBackgroundColor">@android:color/transparent</item>
 		<item name="actionModeBackground">@drawable/background</item>
 	</style>
 

--- a/app/src/main/res/xml/settings_appearance.xml
+++ b/app/src/main/res/xml/settings_appearance.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <PreferenceScreen xmlns:android="http://schemas.android.com/apk/res/android"
-	xmlns:myns="http://schemas.android.com/apk/res/github.paroj.dsub2000"
+    xmlns:myns="http://schemas.android.com/apk/res-auto"
 	android:title="@string/settings.appearance_title">
 
 	<PreferenceCategory
@@ -24,6 +24,16 @@
 			android:summary="@string/settings.color_action_bar.summary"
 			android:key="colorActionBar"
 			android:defaultValue="true"/>
+
+        <github.paroj.dsub2000.view.ColorPickerPreference
+            android:title="@string/settings.general_action_bar_color"
+            android:summary="@string/settings.general_action_bar_color_summary"
+            android:key="actionBarColor"/>
+
+        <github.paroj.dsub2000.view.ColorPickerPreference
+            android:title="@string/settings.now_playing_action_bar_color"
+            android:summary="@string/settings.now_playing_action_bar_color_summary"
+            android:key="actionBarColorNowPlaying"/>
 	</PreferenceCategory>
 
 	<PreferenceCategory


### PR DESCRIPTION
### Description
As discussed in #93, I worked on a small theme update to improve Action Bar color handling, especially when using dark or AMOLED-friendly themes.

With the black theme enabled, almost the entire UI is fully black, while the Action Bar remains brightly colored. This makes the Action Bar the only element that visually stands out on the screen. Currently, the only way to avoid this is to completely disable the “color action bar” option.

This PR introduces more granular control over Action Bar colors and improves visual consistency as well as screen differentiation.

### Changes included
- Updated `lightPrimaryDark` from Material Blue 600 (`#1e88e5`) to Material Blue 900 (`#0d47a1`)  
  - The previous value was too close to `lightPrimary` (Material Blue 500 – `#2196f3`)
- Added separate configurable colors for:
  - **Main toolbar**
  - **Now Playing toolbar**
- The Now Playing toolbar now uses `lightPrimaryDark`, while the main toolbar continues to use `lightPrimary` by default
- Introduced a custom color picker using `ColorPickerPreference`
- Main toolbar and Now Playing toolbar colors can now be adjusted independently via settings


