### PR TITLE
Direct "Add to Playlist" Button in Now Playing Cover View

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/fragments/NowPlayingFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/NowPlayingFragment.java
@@ -14,6 +14,7 @@
 */
 package github.paroj.dsub2000.fragments;
 
+import java.util.Collections;
 import java.util.LinkedList;
 import java.util.List;
 import java.util.concurrent.Executors;
@@ -115,6 +116,7 @@ public class NowPlayingFragment extends SubsonicFragment implements OnGestureLis
 	private ImageButton repeatButton;
 	private View toggleListButton;
 	private ImageButton starButton;
+    private ImageButton addToPlaylist;
 	private ImageButton bookmarkButton;
 	private ImageButton rateBadButton;
 	private ImageButton rateGoodButton;
@@ -210,6 +212,15 @@ public class NowPlayingFragment extends SubsonicFragment implements OnGestureLis
 		} else {
 			starButton.setVisibility(View.GONE);
 		}
+
+        addToPlaylist = (ImageButton)rootView.findViewById(R.id.download_add_to_playlist);
+        addToPlaylist.setOnClickListener(new OnClickListener() {
+            @Override
+            public void onClick(View v) {
+                Entry song = currentPlaying.getSong();
+                addToPlaylist(Collections.singletonList(song));
+            }
+        });
 
 		View.OnTouchListener touchListener = new View.OnTouchListener() {
 			@Override

--- a/app/src/main/res/layout-land/download.xml
+++ b/app/src/main/res/layout-land/download.xml
@@ -56,6 +56,12 @@
 					android:src="?attr/star"
 					android:tint="?attr/element_color"/>
 
+                <ImageButton
+                    android:id="@+id/download_add_to_playlist"
+                    style="@style/DownloadActionImageButton"
+                    android:src="@drawable/ic_action_add"
+                    android:tint="?attr/element_color" />
+
 				<ImageButton
 					android:id="@+id/download_playback_speed"
 					style="@style/DownloadActionImageButton"

--- a/app/src/main/res/layout-large-land/download.xml
+++ b/app/src/main/res/layout-large-land/download.xml
@@ -53,6 +53,12 @@
 						android:src="?attr/star"
 						android:tint="?attr/element_color"/>
 
+                    <ImageButton
+                        android:id="@+id/download_add_to_playlist"
+                        style="@style/DownloadActionImageButton"
+                        android:src="@drawable/ic_action_add"
+                        android:tint="?attr/element_color" />
+
 					<ImageButton
 						android:id="@+id/download_playback_speed"
 						style="@style/DownloadActionImageButton"

--- a/app/src/main/res/layout-port/download.xml
+++ b/app/src/main/res/layout-port/download.xml
@@ -61,6 +61,12 @@
 								style="@style/DownloadActionImageButton"
 								android:src="@drawable/ic_toggle_star" />
 
+                            <ImageButton
+                                android:id="@+id/download_add_to_playlist"
+                                style="@style/DownloadActionImageButton"
+                                android:src="@drawable/ic_action_add"
+                                android:tint="@android:color/white" />
+
 							<ImageButton
 								android:id="@+id/download_playback_speed"
 								style="@style/DownloadActionImageButton"

--- a/app/src/main/res/values/styles.xml
+++ b/app/src/main/res/values/styles.xml
@@ -89,7 +89,7 @@
 		<item name="android:layout_height">wrap_content</item>
 		<item name="android:paddingTop">8dip</item>
 		<item name="android:paddingBottom">8dip</item>
-		<item name="android:paddingRight">16dip</item>
-		<item name="android:paddingLeft">16dip</item>
+		<item name="android:paddingRight">14dip</item>
+		<item name="android:paddingLeft">14dip</item>
 	</style>
 </resources>


### PR DESCRIPTION
This Pull Request implements a new shortcut button in the **Now Playing cover view** to allow users to quickly add the currently playing track to a playlist.

As discussed in issue **#93**, I've added a new button to the control bar that overlays the bottom part of the album art.

* **Current Workflow:** To add the current track to a playlist, the user must currently navigate through several steps:
    1.  Switch from the Cover View to the List View.
    2.  Locate the current track in the list.
    3.  Open the "More" menu (three dots).
    4.  Select "Add to playlist".

