### PR TITLE
Fix Save Playlist for large playlists and improve overwrite handling

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/fragments/SubsonicFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/SubsonicFragment.java
@@ -39,6 +39,9 @@ import androidx.recyclerview.widget.GridLayoutManager;
 import androidx.recyclerview.widget.LinearLayoutManager;
 import androidx.recyclerview.widget.RecyclerView;
 import androidx.appcompat.widget.SearchView;
+
+import android.text.Editable;
+import android.text.TextWatcher;
 import android.util.Log;
 import android.view.GestureDetector;
 import android.view.Menu;
@@ -1129,6 +1132,7 @@ public class SubsonicFragment extends Fragment implements SwipeRefreshLayout.OnR
 		View layout = context.getLayoutInflater().inflate(R.layout.save_playlist, null);
 		final EditText playlistNameView = (EditText) layout.findViewById(R.id.save_playlist_name);
 		final CheckBox overwriteCheckBox = (CheckBox) layout.findViewById(R.id.save_playlist_overwrite);
+
 		if(getSuggestion) {
 			DownloadService downloadService = getDownloadService();
 			String playlistName = null;
@@ -1140,15 +1144,28 @@ public class SubsonicFragment extends Fragment implements SwipeRefreshLayout.OnR
 			if (playlistName != null) {
 				playlistNameView.setText(playlistName);
 				if(playlistId != null) {
-					try {
-						if (ServerInfo.checkServerVersion(context, "1.8.0") && Integer.parseInt(playlistId) != -1) {
-							overwriteCheckBox.setChecked(true);
-							overwriteCheckBox.setVisibility(View.VISIBLE);
-						}
-					} catch (Exception e) {
-						Log.i(TAG, "Playlist id isn't a integer, probably MusicCabinet", e);
-					}
+                    if (ServerInfo.checkServerVersion(context, "1.8.0")) {
+                        overwriteCheckBox.setChecked(true);
+                    }
 				}
+                final String initialPlaylistName = playlistName;
+                playlistNameView.addTextChangedListener(new TextWatcher() {
+                    @Override
+                    public void afterTextChanged(Editable s) {
+                        String currentPlaylistName = s.toString();
+                        boolean isCheckBoxSet = currentPlaylistName.equals(initialPlaylistName);
+                        overwriteCheckBox.setChecked(isCheckBoxSet);
+
+                    }
+                    @Override
+                    public void beforeTextChanged(CharSequence s, int start, int count, int after) {
+
+                    }
+                    @Override
+                    public void onTextChanged(CharSequence s, int start, int before, int count) {
+
+                    }
+                });
 			} else {
 				DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
 				playlistNameView.setText(dateFormat.format(new Date()));
@@ -1156,30 +1173,15 @@ public class SubsonicFragment extends Fragment implements SwipeRefreshLayout.OnR
 		} else {
 			DateFormat dateFormat = new SimpleDateFormat("yyyy-MM-dd");
 			playlistNameView.setText(dateFormat.format(new Date()));
+            overwriteCheckBox.setChecked(false);
+            overwriteCheckBox.setVisibility(View.GONE);
 		}
 
 		AlertDialog.Builder builder = new AlertDialog.Builder(context);
 		builder.setTitle(R.string.download_playlist_title)
 				.setMessage(R.string.download_playlist_name)
 				.setView(layout)
-				.setPositiveButton(R.string.common_save, new DialogInterface.OnClickListener() {
-					@Override
-					public void onClick(DialogInterface dialog, int id) {
-						String playlistName = String.valueOf(playlistNameView.getText());
-						if(overwriteCheckBox.isChecked()) {
-							overwritePlaylist(songs, playlistName, getDownloadService().getSuggestedPlaylistId());
-						} else {
-							createNewPlaylist(songs, playlistName);
-
-							if(getSuggestion) {
-								DownloadService downloadService = getDownloadService();
-								if(downloadService != null) {
-									downloadService.setSuggestedPlaylistName(playlistName, null);
-								}
-							}
-						}
-					}
-				})
+				.setPositiveButton(R.string.common_save, null)
 				.setNegativeButton(R.string.common_cancel, new DialogInterface.OnClickListener() {
 					@Override
 					public void onClick(DialogInterface dialog, int id) {
@@ -1187,61 +1189,99 @@ public class SubsonicFragment extends Fragment implements SwipeRefreshLayout.OnR
 					}
 				})
 				.setCancelable(true);
-
 		AlertDialog dialog = builder.create();
+		dialog.setOnShowListener(new DialogInterface.OnShowListener() {
+            @Override
+            public void onShow(DialogInterface dialogInterface) {
+                Button positiveButton = dialog.getButton(AlertDialog.BUTTON_POSITIVE);
+                positiveButton.setOnClickListener(new View.OnClickListener() {
+                    @Override
+                    public void onClick(View view) {
+                        new SilentBackgroundTask<Void>(context) {
+                            @Override
+                            protected Void doInBackground() throws Throwable {
+                                String playlistName = String.valueOf(playlistNameView.getText());
+                                MusicService musicService = MusicServiceFactory.getMusicService(context);
+                                String playlistId = null;
+                                String username = UserUtil.getCurrentUsername(context);
+                                List<Playlist> playlists = musicService.getPlaylists(true, context, null);
+                                boolean isPlaylistNameUsed = false;
+                                if (username != null) {
+                                    isPlaylistNameUsed = playlists.stream().anyMatch(playlist -> {
+                                        boolean matchesName = playlistName.equals(playlist.getName());
+                                        boolean matchesOwner = username.equals(playlist.getOwner());
+                                        return matchesName && matchesOwner;
+                                    });
+                                }
+                                if (overwriteCheckBox.isChecked() && isPlaylistNameUsed) {
+                                    // overwrite existing
+                                    playlistId = getDownloadService().getSuggestedPlaylistId();
+
+                                    // Check if the loaded playlistId and playlistName match.
+                                    // It is possible that an playlistId is loaded via getSuggestedPlaylistId(),
+                                    // but the name was manually edited to overwrite another playlist with the same name.
+                                    boolean isPlaylistIdValid = true;
+                                    if (playlistId != null) {
+                                        String finalPlaylistId = playlistId;
+                                        isPlaylistIdValid = playlists.stream().anyMatch(playlist -> {
+                                            boolean matchesId = finalPlaylistId.equals(playlist.getId());
+                                            boolean matchesName = playlistName.equals(playlist.getName());
+                                            boolean matchesOwner = username.equals(playlist.getOwner());
+                                            return matchesId && matchesName && matchesOwner;
+                                        });
+                                    }
+                                    if (!isPlaylistIdValid) {
+                                        playlistId = null;
+                                    }
+                                    if (playlistId == null) {
+                                        // find playlist by name
+                                        Playlist filteredPlaylist = playlists.stream().filter(playlist -> {
+                                            boolean matchesName = playlistName.equals(playlist.getName());
+                                            boolean matchesOwner = username.equals(playlist.getOwner());
+                                            return matchesName && matchesOwner;
+                                        }).findFirst().orElse(null);
+                                        if (filteredPlaylist != null) {
+                                            playlistId = filteredPlaylist.getId();
+                                        }
+                                    }
+                                    dialog.dismiss();
+                                    playlistId = musicService.overwritePlaylist(playlistId, playlistName, songs, context, null);
+                                } else if (!isPlaylistNameUsed) {
+                                    // create new
+                                    dialog.dismiss();
+                                    playlistId = musicService.createPlaylist(null, playlistName, songs, context, null);
+                                } else {
+                                    // name collision warning, don't overwrite
+                                    Util.toast(context, R.string.download_playlist_name_in_used);
+                                    return null;
+                                }
+
+                                if(getSuggestion) {
+                                    DownloadService downloadService = getDownloadService();
+                                    if(downloadService != null) {
+                                        downloadService.setSuggestedPlaylistName(playlistName, playlistId);
+                                    }
+                                }
+                                return  null;
+                            };
+
+                            @Override
+                            protected void done(Void result) {
+                                Util.toast(context, R.string.download_playlist_done);
+                            }
+
+                            @Override
+                            protected void error(Throwable error) {
+                                String msg = context.getResources().getString(R.string.download_playlist_error) + " " + getErrorMessage(error);
+                                Log.e(TAG, "Failed to create playlist", error);
+                                Util.toast(context, msg);
+                            }
+                        }.execute();
+                    };
+                });
+            }
+        });
 		dialog.show();
-	}
-	private void createNewPlaylist(final List<Entry> songs, final String name) {
-		new SilentBackgroundTask<Void>(context) {
-			@Override
-			protected Void doInBackground() throws Throwable {
-				MusicService musicService = MusicServiceFactory.getMusicService(context);
-				musicService.createPlaylist(null, name, songs, context, null);
-				return null;
-			}
-
-			@Override
-			protected void done(Void result) {
-				Util.toast(context, R.string.download_playlist_done);
-			}
-
-			@Override
-			protected void error(Throwable error) {
-				String msg = context.getResources().getString(R.string.download_playlist_error) + " " + getErrorMessage(error);
-				Log.e(TAG, "Failed to create playlist", error);
-				Util.toast(context, msg);
-			}
-		}.execute();
-	}
-	private void overwritePlaylist(final List<Entry> songs, final String name, final String id) {
-		new SilentBackgroundTask<Void>(context) {
-			@Override
-			protected Void doInBackground() throws Throwable {
-				MusicService musicService = MusicServiceFactory.getMusicService(context);
-				MusicDirectory playlist = musicService.getPlaylist(true, id, name, context, null);
-				List<Entry> toDelete = playlist.getChildren();
-				musicService.overwritePlaylist(id, name, toDelete.size(), songs, context, null);
-				return null;
-			}
-
-			@Override
-			protected void done(Void result) {
-				Util.toast(context, R.string.download_playlist_done);
-			}
-
-			@Override
-			protected void error(Throwable error) {
-				String msg;
-				if (error instanceof OfflineException || error instanceof ServerTooOldException) {
-					msg = getErrorMessage(error);
-				} else {
-					msg = context.getResources().getString(R.string.download_playlist_error) + " " + getErrorMessage(error);
-				}
-
-				Log.e(TAG, "Failed to overwrite playlist", error);
-				Util.toast(context, msg, false);
-			}
-		}.execute();
 	}
 
 	public void displaySongInfo(final Entry song) {

--- a/app/src/main/java/github/paroj/dsub2000/service/CachedMusicService.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/CachedMusicService.java
@@ -392,10 +392,10 @@ public class CachedMusicService implements MusicService {
     }
 
     @Override
-    public void createPlaylist(String id, String name, List<Entry> entries, Context context, ProgressListener progressListener) throws Exception {
+    public String createPlaylist(String id, String name, List<Entry> entries, Context context, ProgressListener progressListener) throws Exception {
 		cachedPlaylists.clear();
 		Util.delete(new File(context.getCacheDir(), getCacheName(context, "playlist")));
-        musicService.createPlaylist(id, name, entries, context, progressListener);
+        return musicService.createPlaylist(id, name, entries, context, progressListener);
     }
 	
 	@Override
@@ -481,8 +481,8 @@ public class CachedMusicService implements MusicService {
 	}
 	
 	@Override
-	public void overwritePlaylist(String id, String name, int toRemove, final List<Entry> toAdd, Context context, ProgressListener progressListener) throws Exception {
-		musicService.overwritePlaylist(id, name, toRemove, toAdd, context, progressListener);
+	public String overwritePlaylist(String id, String name, final List<Entry> toAdd, Context context, ProgressListener progressListener) throws Exception {
+		String paylistId = musicService.overwritePlaylist(id, name, toAdd, context, progressListener);
 
 		new MusicDirectoryUpdater(context, "playlist", id) {
 			@Override
@@ -496,6 +496,7 @@ public class CachedMusicService implements MusicService {
 				objects.addAll(toAdd);
 			}
 		}.execute();
+        return paylistId;
 	}
 	
 	@Override

--- a/app/src/main/java/github/paroj/dsub2000/service/MusicService.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/MusicService.java
@@ -73,16 +73,16 @@ public interface MusicService {
 
     List<Playlist> getPlaylists(boolean refresh, Context context, ProgressListener progressListener) throws Exception;
 
-    void createPlaylist(String id, String name, List<MusicDirectory.Entry> entries, Context context, ProgressListener progressListener) throws Exception;
+    String createPlaylist(String id, String name, List<MusicDirectory.Entry> entries, Context context, ProgressListener progressListener) throws Exception;
 	
 	void deletePlaylist(String id, Context context, ProgressListener progressListener) throws Exception;
 	
 	void addToPlaylist(String id, List<MusicDirectory.Entry> toAdd, Context context, ProgressListener progressListener) throws Exception;
 	
 	void removeFromPlaylist(String id, List<Integer> toRemove, Context context, ProgressListener progressListener) throws Exception;
-	
-	void overwritePlaylist(String id, String name, int toRemove, List<MusicDirectory.Entry> toAdd, Context context, ProgressListener progressListener) throws Exception;
-	
+
+	String overwritePlaylist(String id, String name, List<MusicDirectory.Entry> toAdd, Context context, ProgressListener progressListener) throws Exception;
+
 	void updatePlaylist(String id, String name, String comment, boolean pub, Context context, ProgressListener progressListener) throws Exception;
 
     Lyrics getLyrics(String artist, String title, Context context, ProgressListener progressListener) throws Exception;

--- a/app/src/main/java/github/paroj/dsub2000/service/OfflineMusicService.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/OfflineMusicService.java
@@ -509,7 +509,7 @@ public class OfflineMusicService implements MusicService {
     }
 
     @Override
-    public void createPlaylist(String id, String name, List<Entry> entries, Context context, ProgressListener progressListener) throws Exception {
+    public String createPlaylist(String id, String name, List<Entry> entries, Context context, ProgressListener progressListener) throws Exception {
 		throw new OfflineException(ERRORMSG);
     }
 	
@@ -529,7 +529,7 @@ public class OfflineMusicService implements MusicService {
 	}
 	
 	@Override
-	public void overwritePlaylist(String id, String name, int toRemove, List<Entry> toAdd, Context context, ProgressListener progressListener) throws Exception {
+	public String overwritePlaylist(String id, String name, List<Entry> toAdd, Context context, ProgressListener progressListener) throws Exception {
 		throw new OfflineException(ERRORMSG);
 	}
 	

--- a/app/src/main/java/github/paroj/dsub2000/service/RESTMusicService.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/RESTMusicService.java
@@ -79,6 +79,7 @@ import github.paroj.dsub2000.util.Constants;
 import github.paroj.dsub2000.util.FileUtil;
 import github.paroj.dsub2000.util.ProgressListener;
 import github.paroj.dsub2000.util.SongDBHandler;
+import github.paroj.dsub2000.util.UserUtil;
 import github.paroj.dsub2000.util.Util;
 import github.paroj.dsub2000.util.compat.GoogleCompat;
 
@@ -377,29 +378,74 @@ public class RESTMusicService implements MusicService {
     }
 
     @Override
-    public void createPlaylist(String id, String name, List<MusicDirectory.Entry> entries, Context context, ProgressListener progressListener) throws Exception {
-        List<String> parameterNames = new LinkedList<String>();
-        List<Object> parameterValues = new LinkedList<Object>();
+    public String createPlaylist(String id, String name, List<MusicDirectory.Entry> entries, Context context, ProgressListener progressListener) throws Exception {
+        // To prevent URLs from exceeding 2048 characters, we first create the playlist
+        // and then update it with the remaining songs.
+        // The base URL (including required parameters) is about 160+ characters long.
+        // One `songIdToAdd` parameter can add up to 35 characters (Navidrom).
+        // With a chunk size of 45, the total URL length is roughly 1800 characters.
+        int chunkSize = 45;
+        List<List<MusicDirectory.Entry>> entriesParts = new ArrayList<>();
 
-        if (id != null) {
-            parameterNames.add("playlistId");
-            parameterValues.add(id);
-        }
-        if (name != null) {
-            parameterNames.add("name");
-            parameterValues.add(name);
-        }
-        for (MusicDirectory.Entry entry : entries) {
-            parameterNames.add("songId");
-            parameterValues.add(getOfflineSongId(entry.getId(), context, progressListener));
+        for (int i = 0; i < entries.size(); i += chunkSize) {
+            List<MusicDirectory.Entry> sublist = entries.subList(i, Math.min(i + chunkSize, entries.size()));
+            entriesParts.add(sublist);
         }
 
-        Reader reader = getReader(context, progressListener, "createPlaylist", parameterNames, parameterValues);
-        try {
-            new ErrorParser(context, getInstance(context)).parse(reader);
-        } finally {
-            Util.close(reader);
+        for (int i = 0; i < entriesParts.size(); i++) {
+            List<MusicDirectory.Entry> entriesPart = entriesParts.get(i);
+            List<String> parameterNames = new LinkedList<String>();
+            List<Object> parameterValues = new LinkedList<Object>();
+            if (id != null) {
+                parameterNames.add("playlistId");
+                parameterValues.add(id);
+            }
+            if (i == 0) {
+                // Create a new playlist; replaces existing content if playlistId is set.
+                if (name != null) {
+                    parameterNames.add("name");
+                    parameterValues.add(name);
+                }
+                for (MusicDirectory.Entry entry : entriesPart) {
+                    parameterNames.add("songId");
+                    parameterValues.add(getOfflineSongId(entry.getId(), context, progressListener));
+                }
+                MusicDirectory createdPlaylist;
+                Reader reader = getReader(context, progressListener, "createPlaylist", parameterNames, parameterValues);
+                try {
+                    createdPlaylist = new PlaylistParser(context, getInstance(context)).parse(reader, progressListener);
+                } finally {
+                    Util.close(reader);
+                }
+                id = createdPlaylist.getId();
+                if (id == null) {
+                    // with airsonic-advanced no id is returned, we have to search for the playlist by name
+                    List<Playlist> playlists = this.getPlaylists(false, context, progressListener);
+                    String username = UserUtil.getCurrentUsername(context);
+                    if (name != null && username != null) {
+                        Playlist filteredPlaylist = playlists.stream().filter(playlist -> {
+                            boolean matchesName = name.equals(playlist.getName());
+                            boolean matchesOwner = username.equals(playlist.getOwner());
+                            return matchesName && matchesOwner;
+                        }).findFirst().orElse(new Playlist());
+                        id = filteredPlaylist.getId();
+                    }
+                }
+            } else {
+                // Update the newly created playlist using the playlistId.
+                for (MusicDirectory.Entry entry : entriesPart) {
+                    parameterNames.add("songIdToAdd");
+                    parameterValues.add(getOfflineSongId(entry.getId(), context, progressListener));
+                }
+                Reader reader = getReader(context, progressListener, "updatePlaylist", parameterNames, parameterValues);
+                try {
+                    new ErrorParser(context, getInstance(context)).parse(reader);
+                } finally {
+                    Util.close(reader);
+                }
+            }
         }
+        return id;
     }
 
 	@Override
@@ -451,28 +497,13 @@ public class RESTMusicService implements MusicService {
 	}
 
 	@Override
-	public void overwritePlaylist(String id, String name, int toRemove, List<MusicDirectory.Entry> toAdd, Context context, ProgressListener progressListener) throws Exception {
+	public String overwritePlaylist(String id, String name, List<MusicDirectory.Entry> toAdd, Context context, ProgressListener progressListener) throws Exception {
 		checkServerVersion(context, "1.8", "Updating playlists is not supported.");
-		List<String> names = new ArrayList<String>();
-		List<Object> values = new ArrayList<Object>();
-		names.add("playlistId");
-		values.add(id);
-		names.add("name");
-		values.add(name);
-		for(MusicDirectory.Entry song: toAdd) {
-			names.add("songIdToAdd");
-			values.add(song.getId());
-		}
-		for(int i = 0; i < toRemove; i++) {
-			names.add("songIndexToRemove");
-			values.add(i);
-		}
-		Reader reader = getReader(context, progressListener, "updatePlaylist", names, values);
-    	try {
-            new ErrorParser(context, getInstance(context)).parse(reader);
-        } finally {
-            Util.close(reader);
+		if (id == null || id.isEmpty()) {
+            throw new IllegalArgumentException("id must be specified when calling overwritePlaylist()");
         }
+        // When calling createPlaylist() with a specified playlistId, existing content is replaced.
+        return this.createPlaylist(id, name, toAdd, context, progressListener);
 	}
 
 	@Override

--- a/app/src/main/res/layout/save_playlist.xml
+++ b/app/src/main/res/layout/save_playlist.xml
@@ -20,7 +20,6 @@
 			android:text="@string/playlist.overwrite"
 			android:layout_marginLeft="4dp"
 			android:checked="false"
-			android:visibility="gone"
 			android:textColor="?android:textColorPrimary"/>
 
 </LinearLayout>

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -187,6 +187,7 @@
     <string name="download.playlist_saving">Sichere Wiedergabeliste \"%s\"...</string>
     <string name="download.playlist_done">Wiedergabeliste wurde erfolgreich gespeichert.</string>
     <string name="download.playlist_error">Fehler beim speichern der Wiedergabeliste, bitte später erneut probieren.</string>
+    <string name="download.playlist_name_in_used">Dieser Name ist bereits vergeben. Bitte wählen Sie einen anderen.</string>
     <string name="download.repeat_off">Keine Wiederholung</string>
     <string name="download.repeat_all">Wiederhole alle</string>
     <string name="download.repeat_single">Aktuelles Lied wiederholen</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -201,6 +201,7 @@
     <string name="download.playlist_saving">Saving playlist \"%s\"...</string>
     <string name="download.playlist_done">Playlist was successfully saved.</string>
     <string name="download.playlist_error">Failed to save playlist, please try later.</string>
+    <string name="download.playlist_name_in_used">This name is already taken. Please choose another one.</string>
     <string name="download.repeat_off">Repeat off</string>
     <string name="download.repeat_all">Repeat all</string>
     <string name="download.repeat_single">Repeat song</string>


### PR DESCRIPTION
As discussed in #93, this PR implements a fix for the "Save playlist" option in the **Now Playing** view. Previously, saving a large playlist could cause an error because all song IDs were concatenated as request parameters, exceeding the URL length limit (~2048 characters).

## Details
- According to the OpenSonic API documentation ([link](https://opensubsonic.netlify.app/docs/endpoints/createplaylist/)), the `songId` parameter can be used multiple times. However, large playlists result in very long URLs, especially with Navidrome, where song IDs can be quite lengthy (e.g., `songId=znRys7cVJ5EXtkJy68DvOk`).
- To prevent URL length issues, playlist entries are now split into chunks of 45 songs:  
  - The first chunk is used to **create** the playlist (using the `createPlaylist` method).  
  - Remaining chunks are **added** using the `updatePlaylist` method.

## Overwrite behavior improvements
- The "Overwrite existing playlist" checkbox is now always shown (except when choosing "Create New").
- Previously, overwriting a playlist used the `updatePlaylist` method, which deleted all existing songs and added the new ones. This approach was also affected by URL length limitations.
- Overwriting now uses the `createPlaylist` method with the `playlistId` parameter provided, which safely replaces all songs.
- If the checkbox is not set and a duplicate playlist name is entered (only checked against playlists of the current user), an error is shown.
- When a playlist is currently being played, the checkbox is preselected. Changing the playlist name removes the checkbox to prevent accidental overwriting.
- The checkbox was never preselected when using Navidrome, since DSub2000 expected an integer ID instead of a string-based playlist ID.

## Summary of changes
- Fixed errors when saving large playlists.
- Improved playlist overwrite behavior and safety.
- Tested with Airsonic-Advanced and Navidrome.
