### PR TITLE
Improve Now Playing Screen Gestures and Album Art Layout

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -102,4 +102,5 @@ dependencies {
 	implementation 'androidx.fragment:fragment:1.8.8'
 	debugImplementation 'org.slf4j:slf4j-api:2.0.17'  // For jupnp logging in debug builds
 	debugImplementation 'uk.uuid.slf4j:slf4j-android:2.0.17-0'
+	implementation 'androidx.palette:palette:1.0.0'
 }

--- a/app/src/main/java/github/paroj/dsub2000/fragments/NowPlayingFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/NowPlayingFragment.java
@@ -21,15 +21,23 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.TimeUnit;
 
+import android.animation.ValueAnimator;
 import android.annotation.TargetApi;
 import androidx.appcompat.app.AlertDialog;
 import android.content.DialogInterface;
 import android.content.Intent;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
+import android.graphics.Bitmap;
+import android.graphics.Color;
+import android.graphics.Rect;
+import android.graphics.drawable.GradientDrawable;
+import android.graphics.drawable.TransitionDrawable;
 import android.os.Build;
 import android.os.Bundle;
 import android.os.Handler;
+
+import androidx.core.graphics.ColorUtils;
 import androidx.core.view.MenuItemCompat;
 import androidx.mediarouter.app.MediaRouteButton;
 import androidx.recyclerview.widget.LinearLayoutManager;
@@ -50,14 +58,15 @@ import android.view.ViewGroup;
 import android.view.WindowManager;
 import android.view.animation.AnimationUtils;
 import android.widget.EditText;
+import android.widget.FrameLayout;
 import android.widget.ImageButton;
-import android.widget.ImageView;
 import android.widget.SeekBar;
 import android.widget.TextView;
 import android.widget.ViewFlipper;
 import com.shehabic.droppy.DroppyClickCallbackInterface;
 import com.shehabic.droppy.DroppyMenuPopup;
 import com.shehabic.droppy.animations.DroppyFadeInAnimation;
+
 import github.paroj.dsub2000.R;
 import github.paroj.dsub2000.activity.SubsonicFragmentActivity;
 import github.paroj.dsub2000.adapter.SectionAdapter;
@@ -78,6 +87,7 @@ import github.paroj.dsub2000.util.SilentBackgroundTask;
 import github.paroj.dsub2000.adapter.DownloadFileAdapter;
 import github.paroj.dsub2000.view.FadeOutAnimation;
 import github.paroj.dsub2000.view.FastScroller;
+import github.paroj.dsub2000.view.RecyclingImageView;
 import github.paroj.dsub2000.view.UpdateView;
 import github.paroj.dsub2000.util.Util;
 
@@ -95,12 +105,15 @@ public class NowPlayingFragment extends SubsonicFragment implements OnGestureLis
 	private static final int ACTION_PREVIOUS = 1;
 	private static final int ACTION_NEXT = 2;
 	private static final int ACTION_REWIND = 3;
-	private static final int ACTION_FORWARD = 4;
+	private static final int ACTION_CLOSE = 4;
 
+    private FrameLayout downloadLayout;
+    private int lastAlbumArtColor;
+    private GradientDrawable glowDrawable;
 	private ViewFlipper playlistFlipper;
 	private TextView emptyTextView;
 	private TextView songTitleTextView;
-	private ImageView albumArtImageView;
+	private RecyclingImageView albumArtImageView;
 	private RecyclerView playlistView;
 	private TextView positionTextView;
 	private TextView durationTextView;
@@ -169,11 +182,63 @@ public class NowPlayingFragment extends SubsonicFragment implements OnGestureLis
 		swipeDistance = (d.getWidth() + d.getHeight()) * PERCENTAGE_OF_SCREEN_FOR_SWIPE / 100;
 		swipeVelocity = (d.getWidth() + d.getHeight()) * PERCENTAGE_OF_SCREEN_FOR_SWIPE / 100;
 		gestureScanner = new GestureDetector(this);
+        downloadLayout = (FrameLayout) rootView.findViewById(R.id.download_album_art_background);
+        downloadLayout.setOnTouchListener(new View.OnTouchListener() {
+            @Override
+            public boolean onTouch(View v, MotionEvent me) {
+                return gestureScanner.onTouchEvent(me);
+            }
+        });
+        albumArtImageView = (RecyclingImageView)rootView.findViewById(R.id.download_album_art_image);
+        if (albumArtImageView != null && downloadLayout != null) {
+            glowDrawable = new GradientDrawable();
+            downloadLayout.setBackground(glowDrawable);
+            albumArtImageView.setOnImageChangedListener(drawable -> {
+                if (drawable instanceof TransitionDrawable) {
+                    return;
+                }
+                Bitmap bitmap = ImageUtil.getBitmapFromDrawable(drawable);
+                int albumArtColor = ImageUtil.getVibrantColorFromBitmap(bitmap, Color.TRANSPARENT);
+                if (albumArtColor == Color.TRANSPARENT || lastAlbumArtColor == albumArtColor) {
+                    return;
+                }
+
+                int gWidth = downloadLayout.getMeasuredWidth();
+                int gHeight = downloadLayout.getMeasuredHeight();
+                float gradientRadius = Math.max(gWidth, gHeight) * 0.52f;
+                glowDrawable.setGradientType(GradientDrawable.RADIAL_GRADIENT);
+                glowDrawable.setGradientRadius(gradientRadius);
+                glowDrawable.setDither(true);
+
+                ValueAnimator animator = ValueAnimator.ofArgb(lastAlbumArtColor, albumArtColor);
+                animator.setDuration(900);
+                animator.addUpdateListener(animation -> {
+                    int color = (int) animation.getAnimatedValue();
+                    glowDrawable.setColors(new int[]{
+                            ColorUtils.setAlphaComponent(color, 100),
+                            ColorUtils.setAlphaComponent(color, 100),
+                            ColorUtils.setAlphaComponent(color, 100),
+                            ColorUtils.setAlphaComponent(color, 80),
+                            ColorUtils.setAlphaComponent(color, 0)
+                    });
+                });
+                animator.start();
+                lastAlbumArtColor = albumArtColor;
+            });
+            albumArtImageView.setOnTouchListener(new View.OnTouchListener() {
+                @Override
+                public boolean onTouch(View v, MotionEvent me) {
+                    if (me.getAction() == MotionEvent.ACTION_DOWN) {
+                        lastY = (int) me.getRawY();
+                    }
+                    return gestureScanner.onTouchEvent(me);
+                }
+            });
+        }
 
 		playlistFlipper = (ViewFlipper)rootView.findViewById(R.id.download_playlist_flipper);
 		emptyTextView = (TextView)rootView.findViewById(R.id.download_empty);
 		songTitleTextView = (TextView)rootView.findViewById(R.id.download_song_title);
-		albumArtImageView = (ImageView)rootView.findViewById(R.id.download_album_art_image);
 		positionTextView = (TextView)rootView.findViewById(R.id.download_position);
 		durationTextView = (TextView)rootView.findViewById(R.id.download_duration);
 		statusTextView = (TextView)rootView.findViewById(R.id.download_status);
@@ -237,15 +302,6 @@ public class NowPlayingFragment extends SubsonicFragment implements OnGestureLis
 		rateCombinedButton.setOnTouchListener(touchListener);
 		playbackSpeedButton.setOnTouchListener(touchListener);
 		emptyTextView.setOnTouchListener(touchListener);
-		albumArtImageView.setOnTouchListener(new View.OnTouchListener() {
-			@Override
-			public boolean onTouch(View v, MotionEvent me) {
-				if (me.getAction() == MotionEvent.ACTION_DOWN) {
-					lastY = (int) me.getRawY();
-				}
-				return gestureScanner.onTouchEvent(me);
-			}
-		});
 
 		previousButton.setOnClickListener(new View.OnClickListener() {
 			@Override
@@ -436,7 +492,7 @@ public class NowPlayingFragment extends SubsonicFragment implements OnGestureLis
 		albumArtImageView.setOnClickListener(new View.OnClickListener() {
 			@Override
 			public void onClick(View view) {
-				if(Util.getPreferences(context).getBoolean(Constants.PREFERENCES_KEY_TAP_COVER_FOR_PLAYLIST, true)) {
+				if(Util.getPreferences(context).getBoolean(Constants.PREFERENCES_KEY_TAP_COVER_FOR_PLAYLIST, false)) {
 					if (overlayHeight == -1 || lastY < (view.getBottom() - overlayHeight)) {
 						toggleFullscreenAlbumArt();
 						setControlsVisible(true);
@@ -1190,12 +1246,21 @@ public class NowPlayingFragment extends SubsonicFragment implements OnGestureLis
 		}
 		// Top to Bottom swipe
 		else if (e2.getY() - e1.getY() > swipeDistance && Math.abs(velocityY) > swipeVelocity) {
-			action = ACTION_FORWARD;
+			action = ACTION_CLOSE;
 		}
 		// Bottom to Top swipe
 		else if (e1.getY() - e2.getY() > swipeDistance && Math.abs(velocityY) > swipeVelocity) {
 			action = ACTION_REWIND;
 		}
+
+        Rect rect = new Rect();
+        albumArtImageView.getGlobalVisibleRect(rect);
+        int x = (int) e1.getRawX();
+        int y = (int) e1.getRawY();
+        boolean startedOnImage = rect.contains(x, y);
+        if (!startedOnImage && action != ACTION_CLOSE) {
+            return false;
+        }
 
 		if(action > 0) {
 			final int performAction = action;
@@ -1210,8 +1275,9 @@ public class NowPlayingFragment extends SubsonicFragment implements OnGestureLis
 						case ACTION_PREVIOUS:
 							downloadService.previous();
 							break;
-						case ACTION_FORWARD:
-							downloadService.fastForward();
+						case ACTION_CLOSE:
+                            SubsonicFragmentActivity activity = (SubsonicFragmentActivity) getActivity();
+                            activity.closeNowPlaying();
 							break;
 						case ACTION_REWIND:
 							downloadService.rewind();

--- a/app/src/main/java/github/paroj/dsub2000/util/ImageUtil.java
+++ b/app/src/main/java/github/paroj/dsub2000/util/ImageUtil.java
@@ -1,0 +1,26 @@
+package github.paroj.dsub2000.util;
+
+import android.graphics.Bitmap;
+import android.graphics.Canvas;
+import android.graphics.drawable.Drawable;
+
+import androidx.palette.graphics.Palette;
+
+public class ImageUtil {
+
+    public static Bitmap getBitmapFromDrawable(Drawable drawable) {
+        int width = drawable.getIntrinsicWidth();
+        int height = drawable.getIntrinsicHeight();
+        Bitmap bitmap = Bitmap.createBitmap(width, height, Bitmap.Config.ARGB_8888);
+        Canvas canvas = new Canvas(bitmap);
+        drawable.setBounds(0, 0, canvas.getWidth(), canvas.getHeight());
+        drawable.draw(canvas);
+        return bitmap;
+    }
+
+    public static int getVibrantColorFromBitmap(Bitmap bitmap, int defaultColor) {
+        Palette palette = Palette.from(bitmap).generate();
+        int dominantColor = palette.getDominantColor(defaultColor);
+        return palette.getVibrantColor(dominantColor);
+    }
+}

--- a/app/src/main/java/github/paroj/dsub2000/view/RecyclingImageView.java
+++ b/app/src/main/java/github/paroj/dsub2000/view/RecyclingImageView.java
@@ -28,6 +28,10 @@ import android.widget.ImageView;
 public class RecyclingImageView extends ImageView {
 	private boolean invalidated = false;
 	private OnInvalidated onInvalidated;
+    private OnImageChangedListener listener;
+    public interface OnImageChangedListener {
+        void onImageChanged(Drawable drawable);
+    }
 
 	public RecyclingImageView(Context context) {
 		super(context);
@@ -84,6 +88,9 @@ public class RecyclingImageView extends ImageView {
 	public void setImageDrawable(Drawable drawable) {
 		super.setImageDrawable(drawable);
 		setInvalidated(false);
+        if (listener != null) {
+            listener.onImageChanged(drawable);
+        }
 	}
 
 	private boolean isBitmapRecycled(Drawable drawable) {
@@ -98,6 +105,10 @@ public class RecyclingImageView extends ImageView {
 			return false;
 		}
 	}
+
+    public void setOnImageChangedListener(OnImageChangedListener listener) {
+        this.listener = listener;
+    }
 
 	public void setInvalidated(boolean invalidated) {
 		this.invalidated = invalidated;

--- a/app/src/main/res/layout-land/download.xml
+++ b/app/src/main/res/layout-land/download.xml
@@ -7,17 +7,25 @@
 
 	<ViewFlipper
 		android:id="@+id/download_playlist_flipper"
-		android:layout_width="match_parent"
+		android:layout_width="0dp"
 		android:layout_height="match_parent"
 		android:layout_weight="1">
 
-		<github.paroj.dsub2000.view.RecyclingImageView
-			android:id="@+id/download_album_art_image"
-			android:src="@drawable/unknown_album_large"
-			android:layout_width="wrap_content"
-			android:layout_height="match_parent"
-			android:layout_weight="1"
-			android:scaleType="fitCenter"/>
+        <FrameLayout
+            android:id="@+id/download_album_art_background"
+            android:clickable="true"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent">
+
+            <github.paroj.dsub2000.view.RecyclingImageView
+                android:id="@+id/download_album_art_image"
+                android:src="@drawable/unknown_album_large"
+                android:layout_width="wrap_content"
+                android:layout_height="wrap_content"
+                android:layout_gravity="center"
+                android:adjustViewBounds="true"
+                android:scaleType="fitCenter"/>
+        </FrameLayout>
 
 		<include layout="@layout/download_playlist"/>
 
@@ -25,7 +33,7 @@
 
 	<RelativeLayout
 		android:id="@+id/download_control_layout"
-		android:layout_width="match_parent"
+        android:layout_width="0dp"
 		android:layout_height="match_parent"
 		android:layout_weight="1"
 		android:background="@android:color/transparent">

--- a/app/src/main/res/layout-large-land/download.xml
+++ b/app/src/main/res/layout-large-land/download.xml
@@ -5,19 +5,27 @@
 	android:layout_width="match_parent"
 	android:layout_height="match_parent">
 
-	<github.paroj.dsub2000.view.RecyclingImageView
-		android:id="@+id/download_album_art_image"
-		android:src="@drawable/unknown_album_large"
-		android:layout_width="match_parent"
-		android:layout_height="match_parent"
-		android:layout_weight="1"
-		android:scaleType="fitCenter"/>
+    <FrameLayout
+        android:id="@+id/download_album_art_background"
+        android:clickable="true"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1">
+
+        <github.paroj.dsub2000.view.RecyclingImageView
+            android:id="@+id/download_album_art_image"
+            android:src="@drawable/unknown_album_large"
+            android:layout_width="match_parent"
+            android:layout_height="match_parent"
+            android:adjustViewBounds="true"
+            android:scaleType="fitCenter"/>
+    </FrameLayout>
 
 	<RelativeLayout
 		android:id="@+id/download_control_layout"
-		android:layout_width="match_parent"
-		android:layout_height="match_parent"
-		android:layout_weight="1"
+        android:layout_width="0dp"
+        android:layout_height="match_parent"
+        android:layout_weight="1"
 		android:background="@android:color/transparent">
 
 		<ViewFlipper

--- a/app/src/main/res/layout-port/download.xml
+++ b/app/src/main/res/layout-port/download.xml
@@ -25,13 +25,16 @@
 				android:background="@android:color/transparent">
 
 				<FrameLayout
+                    android:id="@+id/download_album_art_background"
+                    android:clickable="true"
 					android:layout_width="match_parent"
 					android:layout_height="0dp"
 					android:layout_weight="1">
 
 					<FrameLayout android:orientation="vertical"
 						android:layout_width="match_parent"
-						android:layout_height="wrap_content">
+						android:layout_height="wrap_content"
+                        android:layout_gravity="center">
 
 						<github.paroj.dsub2000.view.RecyclingImageView
 							android:id="@+id/download_album_art_image"

--- a/app/src/main/res/xml/settings_playback.xml
+++ b/app/src/main/res/xml/settings_playback.xml
@@ -78,7 +78,7 @@
             android:title="@string/settings.tap_cover_for_playlist"
             android:summary="@string/settings.tap_cover_for_playlist_summary"
             android:key="tapCoverForPlaylist"
-            android:defaultValue="true"/>
+            android:defaultValue="false"/>
 
         <CheckBoxPreference
             android:title="@string/settings.combine_thumbs_up_down"


### PR DESCRIPTION
## Why
As discussed in #93 + #95, on big screens, swiping down on the header to close the Now Playing screen is awkward. Now you can swipe down on the album art or background instead.  
Also, the album art used to sit at the very top, leaving a lot of empty space on tall or wide screens. Now it’s nicely centered (vertically in portrait, horizontally in landscape), and the glow background picks up a vibrant color from the album art for a cleaner, more immersive look. Smooth transitions make it feel extra polished.

## What’s changed
- **"Album art opens playlist"** now defaults to **false**  
- Album art is **centered**  
- Glow background uses a **vibrant color from the album art**  
- Smooth transitions when the glow changes  
- **Swipe gestures updated:**  
  - **Swipe down** on album art or glow background → closes Now Playing screen  
  - **Swipe left** → next track (unchanged)  
  - **Swipe right** → previous track (unchanged)  
  - **Swipe up** → fast reverse (unchanged)

<div>
<img width="30%" alt="grafik" src="https://github.com/user-attachments/assets/eefd3686-8aad-4c55-94b0-db0a3e887ee1" />
<img width="30%" alt="grafik" src="https://github.com/user-attachments/assets/160fa9f9-a26c-49b0-bd2f-4bf31fecc02c" />
<img width="30%" alt="grafik" src="https://github.com/user-attachments/assets/d94aebaa-fefa-4145-a1cf-a6d410a8bb11" />
</div>

Test APK:
[DSub2000_5.6.3-google-debug.apk.zip](https://github.com/user-attachments/files/24350529/DSub2000_5.6.3-google-debug.apk.zip)

