### PR TITLE
Offline mode track and title fix

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/service/OfflineMusicService.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/OfflineMusicService.java
@@ -177,7 +177,6 @@ public class OfflineMusicService implements MusicService {
 			entry.setGrandParent(file.getParentFile().getParent());
 		}
 		entry.setPath(file.getPath().replaceFirst("^" + root + "/" , ""));
-		String title = name;
 		if (file.isFile()) {
 			File artistFolder = file.getParentFile().getParentFile();
 			File albumFolder = file.getParentFile();
@@ -187,23 +186,14 @@ public class OfflineMusicService implements MusicService {
 				entry.setArtist(artistFolder.getName());
 			}
 			entry.setAlbum(albumFolder.getName());
-
-			int index = name.indexOf('-');
-			if(index != -1) {
-				try {
-					entry.setTrack(Integer.parseInt(name.substring(0, index)));
-					title = title.substring(index + 1);
-				} catch(Exception e) {
-					// Failed parseInt, just means track filled out
-				}
-			}
-
+			FileUtil.parseFileNameIntoEntry(entry, name);
 			if(load) {
 				entry.loadMetadata(file);
 			}
-		}
+		} else {
+            entry.setTitle(name);
+        }
 
-		entry.setTitle(title);
 		entry.setSuffix(FileUtil.getExtension(file.getName().replace(".complete", "")));
 
 		File albumArt = FileUtil.getAlbumArtFile(context, entry);

--- a/app/src/main/java/github/paroj/dsub2000/util/FileUtil.java
+++ b/app/src/main/java/github/paroj/dsub2000/util/FileUtil.java
@@ -34,6 +34,8 @@ import java.util.SortedSet;
 import java.util.TreeSet;
 import java.util.Iterator;
 import java.util.List;
+import java.util.regex.Matcher;
+import java.util.regex.Pattern;
 import java.util.zip.DeflaterOutputStream;
 import java.util.zip.InflaterInputStream;
 
@@ -155,6 +157,45 @@ public class FileUtil {
             fileName = fileName.substring(0, MAX_FILENAME_LENGTH_V2);
         }
         return fileName;
+    }
+
+    public static void parseFileNameIntoEntry(MusicDirectory.Entry entry, String fileName) {
+        String discNumber = null;
+        String trackNumber = null;
+        String title = null;
+
+        Pattern fileNameV2 = Pattern.compile("(\\d{2})-(\\d{3})-(.+)");
+        Matcher matcher = fileNameV2.matcher(fileName);
+        if (matcher.matches()) {
+            discNumber = matcher.group(1);
+            trackNumber = matcher.group(2);
+            title = matcher.group(3);
+        } else {
+            Pattern fileNameV1 = Pattern.compile("(\\d{2})-(.+)");
+            matcher = fileNameV1.matcher(fileName);
+            if (matcher.matches()) {
+                trackNumber = matcher.group(1);
+                title = matcher.group(2);
+            }
+        }
+
+        if (discNumber != null) {
+            try {
+                entry.setDiscNumber(Integer.parseInt(discNumber));
+            } catch(Exception e) {
+                entry.setDiscNumber(1);
+            }
+        }
+        if (trackNumber != null) {
+            try {
+                entry.setTrack(Integer.parseInt(trackNumber));
+            } catch(Exception e) {
+                entry.setTrack(1);
+            }
+        }
+        if (title != null) {
+            entry.setTitle(title);
+        }
     }
 
     private static String getSongFileNameFull(String fileName, String stage, String extension) {


### PR DESCRIPTION
This PR fixes **#105**.

It adds a new `parseFileNameIntoEntry` method to `FileUtil`, which is used by `OfflineMusicService` to extract the track number, title, and disc number from the file name.

For backward compatibility, the old file name pattern is still supported if the new pattern does not match.

Test APK
[DSub2000_5.7.0-google-debug.apk.zip](https://github.com/user-attachments/files/24690176/DSub2000_5.7.0-google-debug.apk.zip)
