### PR TITLE
Fix back stack in SettingsActivity

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/activity/SettingsActivity.java
+++ b/app/src/main/java/github/paroj/dsub2000/activity/SettingsActivity.java
@@ -22,6 +22,9 @@ import android.annotation.TargetApi;
 import android.content.SharedPreferences;
 import android.os.Build;
 import android.os.Bundle;
+import android.window.OnBackInvokedCallback;
+import android.window.OnBackInvokedDispatcher;
+
 import androidx.appcompat.widget.Toolbar;
 
 import github.paroj.dsub2000.R;
@@ -33,6 +36,7 @@ import github.paroj.dsub2000.util.Util;
 public class SettingsActivity extends SubsonicActivity {
 	private static final String TAG = SettingsActivity.class.getSimpleName();
 	private PreferenceCompatFragment fragment;
+    private OnBackInvokedCallback backCallback;
 
 	@TargetApi(Build.VERSION_CODES.ICE_CREAM_SANDWICH_MR1)
 	@Override
@@ -63,5 +67,35 @@ public class SettingsActivity extends SubsonicActivity {
             }
         }
         setSupportActionBar(mainToolbar);
+
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            backCallback = new OnBackInvokedCallback() {
+                @Override
+                public void onBackInvoked() {
+                    onBackPressed();
+                }
+            };
+            getOnBackInvokedDispatcher().registerOnBackInvokedCallback(
+                    OnBackInvokedDispatcher.PRIORITY_DEFAULT,
+                    backCallback
+            );
+        }
 	}
+
+    @Override
+    public void onBackPressed() {
+        if (!backStack.isEmpty()) {
+            removeCurrent();
+            return;
+        }
+        super.onBackPressed();
+    }
+
+    @Override
+    protected void onDestroy() {
+        if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU && backCallback != null) {
+            getOnBackInvokedDispatcher().unregisterOnBackInvokedCallback(backCallback);
+        }
+        super.onDestroy();
+    }
 }


### PR DESCRIPTION
When using the back button in the app - whether the device’s back button or the back gesture within a settings submenu - you were always returned to the home screen instead of the main settings menu. This has been fixed with this pull request.
