### PR TITLE
Add disc to song details & remove starred

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/fragments/SubsonicFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/SubsonicFragment.java
@@ -1350,6 +1350,10 @@ public class SubsonicFragment extends Fragment implements SwipeRefreshLayout.OnR
 				details.add(song.getAlbum());
 			}
 		}
+        if(song.getDiscNumber() != null && song.getDiscNumber() != 0) {
+            headers.add(R.string.details_disc);
+            details.add(Integer.toString(song.getDiscNumber()));
+        }
 		if(song.getTrack() != null && song.getTrack() != 0) {
 			headers.add(R.string.details_track);
 			details.add(Integer.toString(song.getTrack()));
@@ -1395,9 +1399,6 @@ public class SubsonicFragment extends Fragment implements SwipeRefreshLayout.OnR
 			headers.add(R.string.details_rating);
 			details.add(song.getRating() + " stars");
 		}
-
-		headers.add(R.string.details_starred);
-		details.add(Util.formatBoolean(context, song.isStarred()));
 
 		try {
 			Long[] dates = SongDBHandler.getHandler(context).getLastPlayed(song);

--- a/app/src/main/res/values-de/strings.xml
+++ b/app/src/main/res/values-de/strings.xml
@@ -607,7 +607,8 @@
 	<string name="details.title.song">Mediumdetails</string>
 	<string name="details.used_space">Genutzter Platz</string>
 	<string name="details.url">URL</string>
-	<string name="details.track">Medium</string>
+    <string name="details.disc">Medium</string>
+	<string name="details.track">Titelnummer</string>
 	<string name="details.year">Jahr</string>
 	<string name="details.version">Version</string>
 	<string name="playlist.mine">Meine Wiedergabelisten</string>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -642,6 +642,7 @@
 	<string name="details.status">Status</string>
 	<string name="details.artist">Artist</string>
 	<string name="details.album">Album</string>
+    <string name="details.disc">Disc</string>
 	<string name="details.track">Track</string>
 	<string name="details.genre">Genre</string>
 	<string name="details.year">Year</string>


### PR DESCRIPTION
This pull request adds “Disc” to the “Song Details” dialog. To make space, “Starred” has been removed since it was quite redundant (it is already indicated by the blue star on the corresponding track).

Additionally, the German translation of “Track” has been updated from “Medium” to “Titelnummer.” “Medium” actually refers more to the disc number than to the track number.

<img width="405" height="742" alt="grafik" src="https://github.com/user-attachments/assets/23c09e9d-380e-4517-82b1-112353dc3073" />
