### PR TITLE
fixing AVRCP media browsing for Android 16

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -42,7 +42,7 @@
     	android:theme="@style/Theme.DSub2000.Light"
 		android:largeHeap="true"
 		android:usesCleartextTraffic="true">
-    	
+
         <uses-library android:name="android.test.runner" />
 
 		<activity android:name="github.paroj.dsub2000.activity.SubsonicFragmentActivity"
@@ -54,6 +54,12 @@
 				<category android:name="android.intent.category.LAUNCHER"/>
 				<category android:name="android.intent.category.LEANBACK_LAUNCHER"/>
 			</intent-filter>
+            <intent-filter>
+                <action android:name="android.intent.action.VIEW" />
+                <category android:name="android.intent.category.DEFAULT" />
+                <data android:scheme="content" />
+                <data android:mimeType="audio/*" />
+            </intent-filter>
 		</activity>
 
         <activity android:name="github.paroj.dsub2000.activity.SettingsActivity"


### PR DESCRIPTION
As per 

https://issuetracker.google.com/issues/492744341

and

https://github.com/anegrin/Debutante/pull/2

Since Android 16 BT the app should not only expose a service for the intent "android.media.browse.MediaBrowserService", but also an activity with intent-filter for "audio/*" viewing

more details in the issue https://issuetracker.google.com/issues/492744341