### PR TITLE
Fix NullPointerException on add to playlist when a private playlist exists.

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/fragments/SubsonicFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/SubsonicFragment.java
@@ -1039,7 +1039,7 @@ public class SubsonicFragment extends Fragment implements SwipeRefreshLayout.OnR
 				Iterator<Playlist> it = playlists.iterator();
 				while(it.hasNext()) {
 					Playlist playlist = it.next();
-					if(playlist.getPublic() == true && playlist.getId().indexOf(".m3u") == -1 && !UserUtil.getCurrentUsername(context).equals(playlist.getOwner())) {
+					if(Boolean.TRUE.equals(playlist.getPublic()) && playlist.getId().indexOf(".m3u") == -1 && !UserUtil.getCurrentUsername(context).equals(playlist.getOwner())) {
 						it.remove();
 					}
 				}


### PR DESCRIPTION
Fixes #123.
Null safe handling of private playlists when the '+' button is pressed to add a song to a playlist. The previous code was just comparing playlist.getPublic() to a boolean which caused the error on a null playlist.pub value.
