### PR TITLE
Use server-provided coverArt ID for playlists

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/domain/Playlist.java
+++ b/app/src/main/java/github/paroj/dsub2000/domain/Playlist.java
@@ -41,6 +41,7 @@ public class Playlist implements Serializable {
 	private Date created;
 	private Date changed;
 	private Integer duration;
+	private String coverArt;
 
 	public Playlist() {
 
@@ -49,7 +50,7 @@ public class Playlist implements Serializable {
         this.id = id;
         this.name = name;
     }
-	public Playlist(String id, String name, String owner, String comment, String songCount, String pub, Date created, Date changed, Integer duration) {
+	public Playlist(String id, String name, String owner, String comment, String songCount, String pub, Date created, Date changed, Integer duration, String coverArt) {
         this.id = id;
         this.name = name;
 		this.owner = (owner == null) ? "" : owner;
@@ -59,6 +60,7 @@ public class Playlist implements Serializable {
 		this.created = created;
 		this.changed = changed;
 		this.duration = duration;
+		this.coverArt = coverArt;
     }
 
     public String getId() {
@@ -150,6 +152,13 @@ public class Playlist implements Serializable {
 	}
 	public void setDuration(Integer duration) {
 		this.duration = duration;
+	}
+
+	public String getCoverArt() {
+		return coverArt;
+	}
+	public void setCoverArt(String coverArt) {
+		this.coverArt = coverArt;
 	}
 
 	@Override

--- a/app/src/main/java/github/paroj/dsub2000/service/parser/PlaylistsParser.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/parser/PlaylistsParser.java
@@ -59,7 +59,8 @@ public class PlaylistsParser extends AbstractParser {
 					Date created = Util.parseDate(context, get("created"));
 					Date changed = Util.parseDate(context, get("changed"));
 					Integer duration = getInteger("duration");
-                    result.add(new Playlist(id, name, owner, comment, songCount, pub, created, changed, duration));
+					String coverArt = get("coverArt");
+                    result.add(new Playlist(id, name, owner, comment, songCount, pub, created, changed, duration, coverArt));
                 } else if ("error".equals(tag)) {
                     handleError();
                 }

--- a/app/src/main/java/github/paroj/dsub2000/util/ImageLoader.java
+++ b/app/src/main/java/github/paroj/dsub2000/util/ImageLoader.java
@@ -346,7 +346,7 @@ public class ImageLoader {
 			entry.setTitle(playlist.getName());
 		}
 		entry.setId(id);
-		entry.setCoverArt(id);
+		entry.setCoverArt(playlist.getCoverArt() != null ? playlist.getCoverArt() : id);
 		// So this isn't treated as a artist
 		entry.setParent("");
 


### PR DESCRIPTION
## Summary
- Parse the `coverArt` attribute from the `getPlaylists` API response instead of constructing it client-side
- The `ImageLoader` was prepending `pl-` to the playlist ID, which caused a doubled prefix (e.g. `pl-pl-2274`) on servers where the coverArt ID already includes the prefix
- Falls back to the old constructed ID when the server doesn't provide a `coverArt` attribute

## Changes
- `Playlist.java`: added `coverArt` field with getter/setter
- `PlaylistsParser.java`: parse `coverArt` attribute from server response  
- `ImageLoader.java`: use `playlist.getCoverArt()` when available

## Test plan
- Verified playlist cover art loads correctly with a Subsonic server
- Confirmed the API request uses the server-provided coverArt ID (`pl-1`) instead of a client-constructed one

Fixes #54