### PR TITLE
feat: match persistentNotification behavior with default UI state

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/service/DownloadService.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/DownloadService.java
@@ -1550,7 +1550,7 @@ public class DownloadService extends Service {
 		if (show) {
 			Notifications.showPlayingNotification(this, this, handler, currentPlaying.getSong(), usingMediaStyleNotification);
 		} else if (pause) {
-			if (prefs.getBoolean(Constants.PREFERENCES_KEY_PERSISTENT_NOTIFICATION, false)) {
+			if (prefs.getBoolean(Constants.PREFERENCES_KEY_PERSISTENT_NOTIFICATION, true)) {
 				Notifications.showPlayingNotification(this, this, handler, currentPlaying.getSong(), usingMediaStyleNotification);
 			} else {
 				Notifications.hidePlayingNotification(this, this, handler);

--- a/app/src/main/java/github/paroj/dsub2000/util/Notifications.java
+++ b/app/src/main/java/github/paroj/dsub2000/util/Notifications.java
@@ -292,7 +292,7 @@ public final class Notifications {
 		rv.setTextViewText(R.id.notification_artist, artist);
 		rv.setTextViewText(R.id.notification_album, album);
 
-		boolean persistent = Util.getPreferences(context).getBoolean(Constants.PREFERENCES_KEY_PERSISTENT_NOTIFICATION, false);
+		boolean persistent = Util.getPreferences(context).getBoolean(Constants.PREFERENCES_KEY_PERSISTENT_NOTIFICATION, true);
 		if(persistent) {
 			if(expanded) {
 				rv.setImageViewResource(R.id.control_pause, playing ? R.drawable.notification_media_pause : R.drawable.notification_media_start);


### PR DESCRIPTION
small fix, self-explanatory. The UI reports that persistentNotification is true by default, however the code says otherwise. If the desired default is to not have persistentNotifications on by default, then the checkboxPreference should be changed to reflect that.