### PR TITLE
Use ExoPlayer for HTTP streams to fix Ogg/Opus internet radios

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -104,4 +104,10 @@ dependencies {
 	debugImplementation 'org.slf4j:slf4j-api:2.0.17'  // For jupnp logging in debug builds
 	debugImplementation 'uk.uuid.slf4j:slf4j-android:2.0.17-0'
 	implementation 'androidx.palette:palette:1.0.0'
+	// Media3/ExoPlayer for streaming radios with codecs that android.media.MediaPlayer
+	// handles unreliably over HTTP (Ogg Vorbis, Opus, ...). Used for stream playback only;
+	// local files keep using android.media.MediaPlayer via the AudioPlayer abstraction.
+	implementation 'androidx.media3:media3-exoplayer:1.4.1'
+	implementation 'androidx.media3:media3-common:1.4.1'
+	implementation 'androidx.media3:media3-extractor:1.4.1'
 }

--- a/app/src/main/java/github/paroj/dsub2000/service/AudioPlayer.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/AudioPlayer.java
@@ -1,0 +1,93 @@
+/*
+ This file is part of DSub2000.
+ Released under GPLv3, see project LICENSE.txt.
+*/
+package github.paroj.dsub2000.service;
+
+import android.content.Context;
+import android.media.PlaybackParams;
+
+import androidx.annotation.RequiresApi;
+
+/**
+ * Player abstraction used by {@link DownloadService}. Allows different backends
+ * (legacy {@link android.media.MediaPlayer} for local files, ExoPlayer for HTTP
+ * streams) to share the same call sites in DownloadService.
+ *
+ * The method names mirror the subset of {@code MediaPlayer} that DownloadService
+ * relies on, so callers don't have to change semantics. Listeners are reproduced
+ * here (instead of using {@code MediaPlayer.OnPreparedListener} etc.) so the
+ * ExoPlayer-based implementation can satisfy them without depending on
+ * {@code MediaPlayer}.
+ */
+public interface AudioPlayer {
+
+    void setDataSource(String url) throws Exception;
+
+    void prepareAsync();
+
+    void start();
+
+    void pause();
+
+    void stop();
+
+    void reset();
+
+    void release();
+
+    void seekTo(int msec);
+
+    int getCurrentPosition();
+
+    int getDuration();
+
+    boolean isPlaying();
+
+    int getAudioSessionId();
+
+    void setAudioSessionId(int sessionId);
+
+    void setAudioStreamType(int streamType);
+
+    void setVolume(float leftVolume, float rightVolume);
+
+    void setWakeMode(Context context, int mode);
+
+    void setOnPreparedListener(OnPreparedListener listener);
+
+    void setOnCompletionListener(OnCompletionListener listener);
+
+    void setOnErrorListener(OnErrorListener listener);
+
+    void setOnBufferingUpdateListener(OnBufferingUpdateListener listener);
+
+    @RequiresApi(23)
+    PlaybackParams getPlaybackParams();
+
+    @RequiresApi(23)
+    void setPlaybackParams(PlaybackParams params);
+
+    /**
+     * Mirrors {@link android.media.MediaPlayer#setNextMediaPlayer(android.media.MediaPlayer)}
+     * for gapless playback. Implementations that don't support gapless (e.g. the
+     * stream-oriented backend) may treat this as a no-op.
+     */
+    void setNextMediaPlayer(AudioPlayer next);
+
+    interface OnPreparedListener {
+        void onPrepared(AudioPlayer player);
+    }
+
+    interface OnCompletionListener {
+        void onCompletion(AudioPlayer player);
+    }
+
+    interface OnErrorListener {
+        boolean onError(AudioPlayer player, int what, int extra);
+    }
+
+    interface OnBufferingUpdateListener {
+        void onBufferingUpdate(AudioPlayer player, int percent);
+    }
+}

--- a/app/src/main/java/github/paroj/dsub2000/service/DownloadService.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/DownloadService.java
@@ -82,6 +82,9 @@ import android.content.IntentFilter;
 import android.content.SharedPreferences;
 import android.media.AudioManager;
 import android.media.MediaPlayer;
+// AudioPlayer abstraction: legacy MediaPlayer is used for local files via
+// MediaPlayerAudio; HTTP streams (Internet radios with codecs MediaPlayer
+// handles unreliably, e.g. Ogg Vorbis/Opus) go through ExoPlayerAudio.
 import android.media.PlaybackParams;
 import android.media.audiofx.AudioEffect;
 import android.net.wifi.WifiManager;
@@ -130,8 +133,8 @@ public class DownloadService extends Service {
 
 	private final IBinder binder = new SimpleServiceBinder<>(this);
 	private Looper mediaPlayerLooper;
-	private MediaPlayer mediaPlayer;
-	private MediaPlayer nextMediaPlayer;
+	private AudioPlayer mediaPlayer;
+	private AudioPlayer nextMediaPlayer;
 	private int audioSessionId;
 	private boolean nextSetup = false;
 	private final List<DownloadFile> downloadList = new ArrayList<DownloadFile>();
@@ -207,7 +210,9 @@ public class DownloadService extends Service {
 				Looper.prepare();
 
 				mBastpUtil = new BastpUtil();
-				mediaPlayer = new MediaPlayer();
+				// Initial player is MediaPlayer-backed; bufferAndPlay() swaps in the
+				// stream-aware backend when starting an Internet radio.
+				mediaPlayer = new MediaPlayerAudio();
 				mediaPlayer.setWakeMode(DownloadService.this, PowerManager.PARTIAL_WAKE_LOCK);
 
 				// We want to change audio session id's between upgrading Android versions.  Upgrading to Android 7.0 is broken (probably updated session id format)
@@ -238,9 +243,9 @@ public class DownloadService extends Service {
 					}
 				}
 
-				mediaPlayer.setOnErrorListener(new MediaPlayer.OnErrorListener() {
+				mediaPlayer.setOnErrorListener(new AudioPlayer.OnErrorListener() {
 					@Override
-					public boolean onError(MediaPlayer mediaPlayer, int what, int more) {
+					public boolean onError(AudioPlayer player, int what, int more) {
 						handleError(new Exception("MediaPlayer error: " + what + " (" + more + ")"));
 						return false;
 					}
@@ -1195,7 +1200,7 @@ public class DownloadService extends Service {
 			// Next time the cachedPosition is updated, use that as position 0
 			subtractNextPosition = System.currentTimeMillis();
 		}
-		MediaPlayer tmp = mediaPlayer;
+		AudioPlayer tmp = mediaPlayer;
 		mediaPlayer = nextMediaPlayer;
 		nextMediaPlayer = tmp;
 		setCurrentPlaying(nextPlaying, true);
@@ -1960,9 +1965,45 @@ public class DownloadService extends Service {
 		}
 	}
 
+	/**
+	 * If {@code stream} is true, ensure the active player is the ExoPlayer-based
+	 * {@link ExoPlayerAudio} (needed for Ogg/Vorbis/Opus over HTTP, where the
+	 * legacy MediaPlayer is unreliable). Otherwise ensure it is
+	 * {@link MediaPlayerAudio} (so that equalizer / replay-gain / gapless paths
+	 * keep working). Releases the previous player when swapping.
+	 */
+	private AudioPlayer ensurePlayerForStream(AudioPlayer current, boolean stream) {
+		boolean wantExo = stream;
+		boolean haveExo = current instanceof ExoPlayerAudio;
+		if (wantExo == haveExo) {
+			return current;
+		}
+		try {
+			if (current != null) {
+				current.setOnErrorListener(null);
+				current.setOnPreparedListener(null);
+				current.setOnCompletionListener(null);
+				current.setOnBufferingUpdateListener(null);
+				current.release();
+			}
+		} catch (Throwable t) {
+			Log.w(TAG, "Failed to release previous player while swapping backends", t);
+		}
+		AudioPlayer fresh = wantExo ? new ExoPlayerAudio(this) : new MediaPlayerAudio();
+		fresh.setWakeMode(this, PowerManager.PARTIAL_WAKE_LOCK);
+		return fresh;
+	}
+
 	private synchronized void doPlay(final DownloadFile downloadFile, final int position, final boolean start) {
 		try {
 			subtractPosition = 0;
+			// Choose the right backend before configuring the player. For HTTP
+			// streams (Internet radios) we use ExoPlayerAudio because the legacy
+			// android.media.MediaPlayer chokes on Ogg/Vorbis/Opus over HTTP on
+			// many devices; for everything else we keep MediaPlayerAudio so that
+			// existing equalizer / replay-gain / gapless paths keep working
+			// unchanged.
+			mediaPlayer = ensurePlayerForStream(mediaPlayer, downloadFile.isStream());
 			mediaPlayer.setOnCompletionListener(null);
 			mediaPlayer.setOnPreparedListener(null);
 			mediaPlayer.setOnErrorListener(null);
@@ -2003,8 +2044,8 @@ public class DownloadService extends Service {
 			mediaPlayer.setDataSource(dataSource);
 			setPlayerState(PREPARING);
 
-			mediaPlayer.setOnBufferingUpdateListener(new MediaPlayer.OnBufferingUpdateListener() {
-				public void onBufferingUpdate(MediaPlayer mp, int percent) {
+			mediaPlayer.setOnBufferingUpdateListener(new AudioPlayer.OnBufferingUpdateListener() {
+				public void onBufferingUpdate(AudioPlayer mp, int percent) {
 					Log.i(TAG, "Buffered " + percent + "%");
 					if (percent == 100) {
 						mediaPlayer.setOnBufferingUpdateListener(null);
@@ -2012,22 +2053,22 @@ public class DownloadService extends Service {
 				}
 			});
 
-			mediaPlayer.setOnPreparedListener(new MediaPlayer.OnPreparedListener() {
-				public void onPrepared(MediaPlayer mediaPlayer) {
+			mediaPlayer.setOnPreparedListener(new AudioPlayer.OnPreparedListener() {
+				public void onPrepared(AudioPlayer player) {
 					try {
 						setPlayerState(PREPARED);
 
 						synchronized (DownloadService.this) {
 							if (position != 0) {
 								Log.i(TAG, "Restarting player from position " + position);
-								mediaPlayer.seekTo(position);
+								player.seekTo(position);
 							}
 							cachedPosition = position;
 
-							applyReplayGain(mediaPlayer, downloadFile);
+							applyReplayGain(player, downloadFile);
 
 							if (start || autoPlayStart) {
-								mediaPlayer.start();
+								player.start();
 								applyPlaybackParamsMain();
 								setPlayerState(STARTED);
 
@@ -2070,7 +2111,10 @@ public class DownloadService extends Service {
 				return;
 			}
 
-			nextMediaPlayer = new MediaPlayer();
+			// Gapless prefetch only applies to local files (queued tracks); use the
+			// MediaPlayer-backed adapter so setNextMediaPlayer() is honored on the
+			// current player.
+			nextMediaPlayer = new MediaPlayerAudio();
 			nextMediaPlayer.setWakeMode(DownloadService.this, PowerManager.PARTIAL_WAKE_LOCK);
 			try {
 				nextMediaPlayer.setAudioSessionId(audioSessionId);
@@ -2080,8 +2124,8 @@ public class DownloadService extends Service {
 			nextMediaPlayer.setDataSource(file.getPath());
 			setNextPlayerState(PREPARING);
 
-			nextMediaPlayer.setOnPreparedListener(new MediaPlayer.OnPreparedListener() {
-				public void onPrepared(MediaPlayer mp) {
+			nextMediaPlayer.setOnPreparedListener(new AudioPlayer.OnPreparedListener() {
+				public void onPrepared(AudioPlayer mp) {
 					// Changed to different while preparing so ignore
 					if(nextMediaPlayer != mp) {
 						return;
@@ -2102,8 +2146,8 @@ public class DownloadService extends Service {
 				}
 			});
 
-			nextMediaPlayer.setOnErrorListener(new MediaPlayer.OnErrorListener() {
-				public boolean onError(MediaPlayer mediaPlayer, int what, int extra) {
+			nextMediaPlayer.setOnErrorListener(new AudioPlayer.OnErrorListener() {
+				public boolean onError(AudioPlayer player, int what, int extra) {
 					Log.w(TAG, "Error on playing next " + "(" + what + ", " + extra + "): " + downloadFile);
 					return true;
 				}
@@ -2117,8 +2161,8 @@ public class DownloadService extends Service {
 
 	private void setupHandlers(final DownloadFile downloadFile, final boolean isPartial, final boolean isPlaying) {
 		final int duration = downloadFile.getSong().getDuration() == null ? 0 : downloadFile.getSong().getDuration() * 1000;
-		mediaPlayer.setOnErrorListener(new MediaPlayer.OnErrorListener() {
-			public boolean onError(MediaPlayer mediaPlayer, int what, int extra) {
+		mediaPlayer.setOnErrorListener(new AudioPlayer.OnErrorListener() {
+			public boolean onError(AudioPlayer player, int what, int extra) {
 				Log.w(TAG, "Error on playing file " + "(" + what + ", " + extra + "): " + downloadFile);
 				int pos = getPlayerPosition();
 				reset();
@@ -2140,9 +2184,9 @@ public class DownloadService extends Service {
 			}
 		});
 
-		mediaPlayer.setOnCompletionListener(new MediaPlayer.OnCompletionListener() {
+		mediaPlayer.setOnCompletionListener(new AudioPlayer.OnCompletionListener() {
 			@Override
-			public void onCompletion(MediaPlayer mediaPlayer) {
+			public void onCompletion(AudioPlayer player) {
 				setPlayerStateCompleted();
 
 				int pos = getPlayerPosition();
@@ -2686,7 +2730,7 @@ public class DownloadService extends Service {
 		}
 	}
 
-	private void applyReplayGain(MediaPlayer mediaPlayer, DownloadFile downloadFile) {
+	private void applyReplayGain(AudioPlayer mediaPlayer, DownloadFile downloadFile) {
 		if(currentPlaying == null) {
 			return;
 		}
@@ -2810,7 +2854,7 @@ public class DownloadService extends Service {
 		}
 	}
 
-	private synchronized void applyPlaybackParams(MediaPlayer mediaPlayer) {
+	private synchronized void applyPlaybackParams(AudioPlayer mediaPlayer) {
 		if(Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
 			float playbackSpeed = getPlaybackSpeed();
 

--- a/app/src/main/java/github/paroj/dsub2000/service/ExoPlayerAudio.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/ExoPlayerAudio.java
@@ -1,0 +1,258 @@
+/*
+ This file is part of DSub2000.
+ Released under GPLv3, see project LICENSE.txt.
+*/
+package github.paroj.dsub2000.service;
+
+import android.content.Context;
+import android.media.AudioManager;
+import android.media.PlaybackParams;
+import android.os.Handler;
+import android.os.Looper;
+
+import androidx.annotation.OptIn;
+import androidx.annotation.RequiresApi;
+import androidx.media3.common.AudioAttributes;
+import androidx.media3.common.C;
+import androidx.media3.common.MediaItem;
+import androidx.media3.common.PlaybackException;
+import androidx.media3.common.PlaybackParameters;
+import androidx.media3.common.Player;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.exoplayer.ExoPlayer;
+import androidx.media3.exoplayer.source.DefaultMediaSourceFactory;
+
+/**
+ * {@link AudioPlayer} backed by Media3 {@link ExoPlayer}. Used for HTTP streams
+ * (Internet radios) where {@code android.media.MediaPlayer} is unreliable for
+ * Ogg Vorbis / Opus over HTTP. Translates the legacy MediaPlayer-shaped lifecycle
+ * (prepareAsync → onPrepared → start; onCompletion at end) onto ExoPlayer's
+ * state-machine ({@link Player#STATE_BUFFERING}, {@link Player#STATE_READY},
+ * {@link Player#STATE_ENDED}).
+ */
+@OptIn(markerClass = UnstableApi.class)
+public class ExoPlayerAudio implements AudioPlayer {
+
+    private final ExoPlayer player;
+    private final Handler mainHandler;
+
+    private OnPreparedListener preparedListener;
+    private OnCompletionListener completionListener;
+    private OnErrorListener errorListener;
+    private OnBufferingUpdateListener bufferingListener;
+
+    /** Has onPrepared already been delivered for the currently-loaded media? */
+    private boolean preparedDelivered = false;
+
+    public ExoPlayerAudio(Context context) {
+        mainHandler = new Handler(Looper.getMainLooper());
+        // ExoPlayer must be created and accessed on a Looper thread. DownloadService
+        // creates the player on threads without an attached Looper, so we pin to
+        // the application's main Looper.
+        //
+        // Use NoRangeHttpDataSource so the player never sends a Range header. Some
+        // Icecast/Liquidsoap radio servers respond 404 to Range requests (the
+        // default DefaultHttpDataSource always sends Range: bytes=0- to discover
+        // the resource length). For live audio streams Range/length are
+        // unnecessary anyway.
+        DefaultMediaSourceFactory mediaSourceFactory = new DefaultMediaSourceFactory(context)
+                .setDataSourceFactory(new NoRangeHttpDataSource.Factory());
+        player = new ExoPlayer.Builder(context)
+                .setLooper(Looper.getMainLooper())
+                .setMediaSourceFactory(mediaSourceFactory)
+                .build();
+        player.addListener(new Player.Listener() {
+            @Override
+            public void onPlaybackStateChanged(int playbackState) {
+                switch (playbackState) {
+                    case Player.STATE_READY:
+                        if (!preparedDelivered) {
+                            preparedDelivered = true;
+                            if (preparedListener != null) preparedListener.onPrepared(ExoPlayerAudio.this);
+                        }
+                        if (bufferingListener != null) {
+                            bufferingListener.onBufferingUpdate(ExoPlayerAudio.this, 100);
+                        }
+                        break;
+                    case Player.STATE_BUFFERING:
+                        if (bufferingListener != null) {
+                            bufferingListener.onBufferingUpdate(ExoPlayerAudio.this, 0);
+                        }
+                        break;
+                    case Player.STATE_ENDED:
+                        if (completionListener != null) completionListener.onCompletion(ExoPlayerAudio.this);
+                        break;
+                    default:
+                        break;
+                }
+            }
+
+            @Override
+            public void onPlayerError(PlaybackException error) {
+                if (errorListener != null) {
+                    errorListener.onError(ExoPlayerAudio.this, error.errorCode, 0);
+                }
+            }
+        });
+    }
+
+    /** Run a block on the player's Looper. ExoPlayer's API is single-threaded. */
+    private void onPlayerThread(Runnable r) {
+        if (Looper.myLooper() == player.getApplicationLooper()) {
+            r.run();
+        } else {
+            mainHandler.post(r);
+        }
+    }
+
+    @Override
+    public void setDataSource(String url) {
+        onPlayerThread(() -> {
+            preparedDelivered = false;
+            player.setMediaItem(MediaItem.fromUri(url));
+        });
+    }
+
+    @Override
+    public void prepareAsync() {
+        // Pause-by-default mirrors MediaPlayer's prepareAsync → wait-for-onPrepared
+        // → caller decides whether to start(). DownloadService toggles play/pause
+        // explicitly in its onPrepared handler.
+        onPlayerThread(() -> {
+            player.setPlayWhenReady(false);
+            player.prepare();
+        });
+    }
+
+    @Override
+    public void start() {
+        onPlayerThread(() -> {
+            player.setPlayWhenReady(true);
+            // Player#play exists from 1.0.x; equivalent to setPlayWhenReady(true).
+        });
+    }
+
+    @Override
+    public void pause() {
+        onPlayerThread(player::pause);
+    }
+
+    @Override
+    public void stop() {
+        onPlayerThread(player::stop);
+    }
+
+    @Override
+    public void reset() {
+        onPlayerThread(() -> {
+            player.stop();
+            player.clearMediaItems();
+            preparedDelivered = false;
+        });
+    }
+
+    @Override
+    public void release() {
+        onPlayerThread(player::release);
+    }
+
+    @Override
+    public void seekTo(int msec) {
+        onPlayerThread(() -> player.seekTo(msec));
+    }
+
+    @Override
+    public int getCurrentPosition() {
+        return (int) player.getCurrentPosition();
+    }
+
+    @Override
+    public int getDuration() {
+        long d = player.getDuration();
+        // For live streams ExoPlayer reports TIME_UNSET; mimic MediaPlayer (returns 0).
+        return d == C.TIME_UNSET ? 0 : (int) d;
+    }
+
+    @Override
+    public boolean isPlaying() {
+        return player.isPlaying();
+    }
+
+    @Override
+    public int getAudioSessionId() {
+        return player.getAudioSessionId();
+    }
+
+    @Override
+    public void setAudioSessionId(int sessionId) {
+        onPlayerThread(() -> player.setAudioSessionId(sessionId));
+    }
+
+    @Override
+    public void setAudioStreamType(int streamType) {
+        // Translate legacy AudioManager.STREAM_* to Media3 AudioAttributes.
+        final int contentType;
+        final int usage;
+        switch (streamType) {
+            case AudioManager.STREAM_MUSIC:
+            default:
+                contentType = C.AUDIO_CONTENT_TYPE_MUSIC;
+                usage = C.USAGE_MEDIA;
+                break;
+        }
+        AudioAttributes attrs = new AudioAttributes.Builder()
+                .setContentType(contentType)
+                .setUsage(usage)
+                .build();
+        onPlayerThread(() -> player.setAudioAttributes(attrs, /* handleAudioFocus= */ false));
+    }
+
+    @Override
+    public void setVolume(float leftVolume, float rightVolume) {
+        // ExoPlayer is mono volume; average the two channels.
+        final float v = Math.max(0f, Math.min(1f, (leftVolume + rightVolume) / 2f));
+        onPlayerThread(() -> player.setVolume(v));
+    }
+
+    @Override
+    public void setWakeMode(Context context, int mode) {
+        onPlayerThread(() -> player.setWakeMode(mode));
+    }
+
+    @Override
+    public void setOnPreparedListener(OnPreparedListener listener) {
+        this.preparedListener = listener;
+    }
+
+    @Override
+    public void setOnCompletionListener(OnCompletionListener listener) {
+        this.completionListener = listener;
+    }
+
+    @Override
+    public void setOnErrorListener(OnErrorListener listener) {
+        this.errorListener = listener;
+    }
+
+    @Override
+    public void setOnBufferingUpdateListener(OnBufferingUpdateListener listener) {
+        this.bufferingListener = listener;
+    }
+
+    @Override @RequiresApi(23)
+    public PlaybackParams getPlaybackParams() {
+        PlaybackParameters pp = player.getPlaybackParameters();
+        return new PlaybackParams().setSpeed(pp.speed).setPitch(pp.pitch);
+    }
+
+    @Override @RequiresApi(23)
+    public void setPlaybackParams(PlaybackParams params) {
+        final PlaybackParameters pp = new PlaybackParameters(params.getSpeed(), params.getPitch());
+        onPlayerThread(() -> player.setPlaybackParameters(pp));
+    }
+
+    @Override
+    public void setNextMediaPlayer(AudioPlayer next) {
+        // Live HTTP streams have no end of file; gapless does not apply. No-op.
+    }
+}

--- a/app/src/main/java/github/paroj/dsub2000/service/MediaPlayerAudio.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/MediaPlayerAudio.java
@@ -1,0 +1,104 @@
+/*
+ This file is part of DSub2000.
+ Released under GPLv3, see project LICENSE.txt.
+*/
+package github.paroj.dsub2000.service;
+
+import android.content.Context;
+import android.media.MediaPlayer;
+import android.media.PlaybackParams;
+
+import androidx.annotation.RequiresApi;
+
+import java.io.IOException;
+
+/**
+ * {@link AudioPlayer} backed by the legacy {@link android.media.MediaPlayer}. Used
+ * for local files (cached or partial downloads) where {@code MediaPlayer} works
+ * reliably and integrates with the existing replay-gain / equalizer / gapless
+ * paths in {@link DownloadService}.
+ */
+public class MediaPlayerAudio implements AudioPlayer {
+
+    private final MediaPlayer mp = new MediaPlayer();
+
+    /**
+     * Exposes the underlying {@link MediaPlayer} so call sites that need to
+     * interact with the framework directly (e.g. equalizer attached via
+     * audio session, hardware effects) can still do so. Returns null on the
+     * stream-oriented adapter.
+     */
+    public MediaPlayer getMediaPlayer() {
+        return mp;
+    }
+
+    @Override
+    public void setDataSource(String url) throws IOException {
+        mp.setDataSource(url);
+    }
+
+    @Override public void prepareAsync() { mp.prepareAsync(); }
+    @Override public void start() { mp.start(); }
+    @Override public void pause() { mp.pause(); }
+    @Override public void stop() { mp.stop(); }
+    @Override public void reset() { mp.reset(); }
+    @Override public void release() { mp.release(); }
+    @Override public void seekTo(int msec) { mp.seekTo(msec); }
+    @Override public int getCurrentPosition() { return mp.getCurrentPosition(); }
+    @Override public int getDuration() { return mp.getDuration(); }
+    @Override public boolean isPlaying() { return mp.isPlaying(); }
+    @Override public int getAudioSessionId() { return mp.getAudioSessionId(); }
+    @Override public void setAudioSessionId(int id) { mp.setAudioSessionId(id); }
+    @Override public void setAudioStreamType(int streamType) { mp.setAudioStreamType(streamType); }
+    @Override public void setVolume(float l, float r) { mp.setVolume(l, r); }
+    @Override public void setWakeMode(Context c, int mode) { mp.setWakeMode(c, mode); }
+
+    @Override
+    public void setOnPreparedListener(final OnPreparedListener listener) {
+        mp.setOnPreparedListener(listener == null ? null : new MediaPlayer.OnPreparedListener() {
+            @Override public void onPrepared(MediaPlayer ignored) { listener.onPrepared(MediaPlayerAudio.this); }
+        });
+    }
+
+    @Override
+    public void setOnCompletionListener(final OnCompletionListener listener) {
+        mp.setOnCompletionListener(listener == null ? null : new MediaPlayer.OnCompletionListener() {
+            @Override public void onCompletion(MediaPlayer ignored) { listener.onCompletion(MediaPlayerAudio.this); }
+        });
+    }
+
+    @Override
+    public void setOnErrorListener(final OnErrorListener listener) {
+        mp.setOnErrorListener(listener == null ? null : new MediaPlayer.OnErrorListener() {
+            @Override public boolean onError(MediaPlayer ignored, int what, int extra) {
+                return listener.onError(MediaPlayerAudio.this, what, extra);
+            }
+        });
+    }
+
+    @Override
+    public void setOnBufferingUpdateListener(final OnBufferingUpdateListener listener) {
+        mp.setOnBufferingUpdateListener(listener == null ? null : new MediaPlayer.OnBufferingUpdateListener() {
+            @Override public void onBufferingUpdate(MediaPlayer ignored, int percent) {
+                listener.onBufferingUpdate(MediaPlayerAudio.this, percent);
+            }
+        });
+    }
+
+    @Override @RequiresApi(23)
+    public PlaybackParams getPlaybackParams() { return mp.getPlaybackParams(); }
+
+    @Override @RequiresApi(23)
+    public void setPlaybackParams(PlaybackParams params) { mp.setPlaybackParams(params); }
+
+    @Override
+    public void setNextMediaPlayer(AudioPlayer next) {
+        if (next == null) {
+            mp.setNextMediaPlayer(null);
+        } else if (next instanceof MediaPlayerAudio) {
+            mp.setNextMediaPlayer(((MediaPlayerAudio) next).mp);
+        }
+        // Cross-backend gapless (file → stream or vice versa) is not meaningful;
+        // ignore in that case.
+    }
+}

--- a/app/src/main/java/github/paroj/dsub2000/service/NoRangeHttpDataSource.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/NoRangeHttpDataSource.java
@@ -1,0 +1,165 @@
+/*
+ This file is part of DSub2000.
+ Released under GPLv3, see project LICENSE.txt.
+*/
+package github.paroj.dsub2000.service;
+
+import android.net.Uri;
+
+import androidx.annotation.OptIn;
+import androidx.media3.common.C;
+import androidx.media3.common.util.UnstableApi;
+import androidx.media3.datasource.BaseDataSource;
+import androidx.media3.datasource.DataSource;
+import androidx.media3.datasource.DataSpec;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.HttpURLConnection;
+import java.net.URL;
+import java.util.Map;
+
+/**
+ * Minimal {@link DataSource} that fetches an HTTP/HTTPS URL with a plain GET,
+ * never sending a {@code Range} header.
+ *
+ * Some Icecast/Liquidsoap radio servers respond with HTTP 404 when a Range
+ * header is present (e.g. {@code https://zeppelin.streampunk.cc/_stream/...}).
+ * ExoPlayer's default HTTP data source always issues {@code Range: bytes=0-}
+ * to determine the resource length, which trips that misconfiguration. This
+ * implementation deliberately omits Range and reports an unknown length, which
+ * is fine for live audio streams that don't need seeking.
+ *
+ * Used only by {@link ExoPlayerAudio} for stream playback (Internet radios).
+ * Not intended for general-purpose use: it does not support range requests,
+ * resumption, or content-length reporting.
+ */
+@OptIn(markerClass = UnstableApi.class)
+public class NoRangeHttpDataSource extends BaseDataSource {
+
+    private static final int CONNECT_TIMEOUT_MS = 8000;
+    private static final int READ_TIMEOUT_MS = 8000;
+    /** Max redirects to follow manually (HTTP→HTTPS and viceversa). */
+    private static final int MAX_REDIRECTS = 5;
+
+    private DataSpec dataSpec;
+    private HttpURLConnection connection;
+    private InputStream inputStream;
+    private boolean opened;
+
+    public NoRangeHttpDataSource() {
+        super(/* isNetwork= */ true);
+    }
+
+    @Override
+    public long open(DataSpec dataSpec) throws IOException {
+        this.dataSpec = dataSpec;
+        transferInitializing(dataSpec);
+
+        URL currentUrl = new URL(dataSpec.uri.toString());
+        int redirects = 0;
+        while (true) {
+            connection = (HttpURLConnection) currentUrl.openConnection();
+            connection.setRequestMethod("GET");
+            // We follow redirects manually so we can handle HTTP↔HTTPS hops
+            // (Java's setInstanceFollowRedirects refuses cross-protocol).
+            connection.setInstanceFollowRedirects(false);
+            connection.setConnectTimeout(CONNECT_TIMEOUT_MS);
+            connection.setReadTimeout(READ_TIMEOUT_MS);
+            // Forward any caller-supplied request headers, but never Range — that's
+            // the whole reason this data source exists.
+            if (dataSpec.httpRequestHeaders != null) {
+                for (Map.Entry<String, String> entry : dataSpec.httpRequestHeaders.entrySet()) {
+                    if (!"Range".equalsIgnoreCase(entry.getKey())) {
+                        connection.setRequestProperty(entry.getKey(), entry.getValue());
+                    }
+                }
+            }
+
+            int responseCode;
+            try {
+                responseCode = connection.getResponseCode();
+            } catch (IOException e) {
+                disconnectQuietly();
+                throw e;
+            }
+
+            if (responseCode >= 300 && responseCode < 400) {
+                String location = connection.getHeaderField("Location");
+                disconnectQuietly();
+                if (location == null) {
+                    throw new IOException("HTTP " + responseCode + " without Location header for " + dataSpec.uri);
+                }
+                if (++redirects > MAX_REDIRECTS) {
+                    throw new IOException("Too many redirects (" + MAX_REDIRECTS + ") starting at " + dataSpec.uri);
+                }
+                // Resolve relative Location against the URL we just queried.
+                currentUrl = new URL(currentUrl, location);
+                continue;
+            }
+
+            if (responseCode < 200 || responseCode >= 300) {
+                disconnectQuietly();
+                throw new IOException("Unexpected HTTP " + responseCode + " for " + currentUrl);
+            }
+
+            inputStream = connection.getInputStream();
+            opened = true;
+            transferStarted(dataSpec);
+            return C.LENGTH_UNSET;
+        }
+    }
+
+    @Override
+    public int read(byte[] buffer, int offset, int length) throws IOException {
+        if (length == 0) {
+            return 0;
+        }
+        int n = inputStream.read(buffer, offset, length);
+        if (n == -1) {
+            return C.RESULT_END_OF_INPUT;
+        }
+        bytesTransferred(n);
+        return n;
+    }
+
+    @Override
+    public Uri getUri() {
+        return dataSpec == null ? null : dataSpec.uri;
+    }
+
+    @Override
+    public void close() throws IOException {
+        try {
+            if (inputStream != null) {
+                inputStream.close();
+            }
+        } finally {
+            inputStream = null;
+            disconnectQuietly();
+            if (opened) {
+                opened = false;
+                transferEnded();
+            }
+        }
+    }
+
+    private void disconnectQuietly() {
+        if (connection != null) {
+            try {
+                connection.disconnect();
+            } catch (Exception ignored) {
+                // disconnect() is best-effort
+            }
+            connection = null;
+        }
+    }
+
+    /** Factory that produces fresh {@link NoRangeHttpDataSource} instances. */
+    public static class Factory implements DataSource.Factory {
+        @Override
+        public DataSource createDataSource() {
+            return new NoRangeHttpDataSource();
+        }
+    }
+}


### PR DESCRIPTION
## Problem                                                                                                                                                                                                                                         
                  
  Android's legacy `MediaPlayer` fails to play Ogg Vorbis / Opus streams from common Icecast/Liquidsoap setups. Some servers also return HTTP 404 to requests with a `Range` header, which both `MediaPlayer` and ExoPlayer's default HTTP data      
  source send.
                                                                                                                                                                                                                                                     
  ## Approach     

  Introduce an `AudioPlayer` interface with two backends:                                                                                                                                                                                            
  
  - `MediaPlayerAudio` — wraps `android.media.MediaPlayer` for local/transcoded files (unchanged behaviour).                                                                                                                                         
  - `ExoPlayerAudio` — wraps Media3 `ExoPlayer` for HTTP streams (Internet radios). Supports Ogg Vorbis, Opus, MP3, AAC.
                                                                                                                                                                                                                                                     
  `DownloadService.ensurePlayerForStream()` picks the backend based on `DownloadFile.isStream()` and swaps it transparently between tracks.                                                                                                          
                                                                                                                                                                                                                                                     
  `NoRangeHttpDataSource` is a custom Media3 `BaseDataSource` that:                                                                                                                                                                                  
                  
  - never emits a `Range` header (works around Liquidsoap/Icecast servers that 404 on Range);                                                                                                                                                        
  - follows redirects manually, including HTTP↔HTTPS hops (Java's `setInstanceFollowRedirects` refuses cross-protocol redirects).
                                                                                                                                                                                                                                                     
  ## Tested
                                                                                                                                                                                                                                                     
  - MP3 radios (existing behaviour preserved)                                                                                                                                                                                                        
  - Ogg Vorbis radios
  - Opus radios                                                                                                                                                                                                                                      
  - A redirect chain `http://… → https://… → https://different-host/…` (Radio Blackout)
                                                                                                                                                                                                                                                     
  ## Footprint
                                                                                                                                                                                                                                                     
  Adds `androidx.media3:media3-exoplayer`, `media3-common`, `media3-extractor` (1.4.1).
