### PR TITLE
Add multi-folder library filter (resolves #140)

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/activity/SubsonicActivity.java
+++ b/app/src/main/java/github/paroj/dsub2000/activity/SubsonicActivity.java
@@ -382,7 +382,7 @@ public class SubsonicActivity extends AppCompatActivity implements OnItemSelecte
 			public boolean onNavigationItemSelected(final MenuItem menuItem) {
 				if(showingTabs) {
 					// Settings are on a different selectable track
-					if (menuItem.getItemId() != R.id.drawer_settings && menuItem.getItemId() != R.id.drawer_admin && menuItem.getItemId() != R.id.drawer_offline) {
+					if (menuItem.getItemId() != R.id.drawer_settings && menuItem.getItemId() != R.id.drawer_admin && menuItem.getItemId() != R.id.drawer_offline && menuItem.getItemId() != R.id.drawer_library_filter) {
 						menuItem.setChecked(true);
 						lastSelectedPosition = menuItem.getItemId();
 					}
@@ -430,6 +430,9 @@ public class SubsonicActivity extends AppCompatActivity implements OnItemSelecte
 							return true;
 						case R.id.drawer_downloading:
 							drawerItemSelected("Download");
+							return true;
+						case R.id.drawer_library_filter:
+							showLibraryFilterDialog();
 							return true;
 						case R.id.drawer_offline:
 							toggleOffline();
@@ -692,6 +695,29 @@ public class SubsonicActivity extends AppCompatActivity implements OnItemSelecte
 		}
 		if(!adminEnabled) {
 			setDrawerItemVisible(R.id.drawer_admin, false);
+		}
+
+		// Library filter only makes sense online and when the server has ≥ 2 music folders.
+		setDrawerItemVisible(R.id.drawer_library_filter, false);
+		if(!Util.isOffline(this)) {
+			new SilentBackgroundTask<java.util.List<github.paroj.dsub2000.domain.MusicFolder>>(this) {
+				@Override
+				protected java.util.List<github.paroj.dsub2000.domain.MusicFolder> doInBackground() throws Throwable {
+					return MusicServiceFactory.getMusicService(SubsonicActivity.this).getMusicFolders(false, SubsonicActivity.this, null);
+				}
+
+				@Override
+				protected void done(java.util.List<github.paroj.dsub2000.domain.MusicFolder> folders) {
+					if(folders != null && folders.size() > 1) {
+						setDrawerItemVisible(R.id.drawer_library_filter, true);
+					}
+				}
+
+				@Override
+				protected void error(Throwable error) {
+					// Silently leave hidden if folders can't be loaded.
+				}
+			}.execute();
 		}
 
 		if(lastSelectedPosition != 0) {
@@ -1136,6 +1162,46 @@ public class SubsonicActivity extends AppCompatActivity implements OnItemSelecte
 			drawerHeader.setClickable(true);
 			drawerHeaderToggle.setVisibility(View.VISIBLE);
 		}
+	}
+
+	private void showLibraryFilterDialog() {
+		drawer.closeDrawers();
+		if(Util.isOffline(this)) {
+			return;
+		}
+
+		new SilentBackgroundTask<java.util.List<github.paroj.dsub2000.domain.MusicFolder>>(this) {
+			@Override
+			protected java.util.List<github.paroj.dsub2000.domain.MusicFolder> doInBackground() throws Throwable {
+				MusicService musicService = MusicServiceFactory.getMusicService(SubsonicActivity.this);
+				return musicService.getMusicFolders(false, SubsonicActivity.this, null);
+			}
+
+			@Override
+			protected void done(java.util.List<github.paroj.dsub2000.domain.MusicFolder> folders) {
+				if(folders == null || folders.size() <= 1) {
+					return;
+				}
+				github.paroj.dsub2000.adapter.ArtistAdapter.showLibraryFilterDialog(SubsonicActivity.this, folders,
+					new github.paroj.dsub2000.adapter.ArtistAdapter.OnMusicFoldersChanged() {
+						@Override
+						public void onMusicFoldersChanged(java.util.List<github.paroj.dsub2000.domain.MusicFolder> selected) {
+							java.util.List<String> ids = new java.util.ArrayList<>();
+							for(github.paroj.dsub2000.domain.MusicFolder f : selected) {
+								ids.add(f.getId());
+							}
+							Util.setSelectedMusicFolderIds(SubsonicActivity.this, ids);
+							invalidate();
+						}
+					});
+			}
+
+			@Override
+			protected void error(Throwable error) {
+				Log.w(TAG, "Failed to load music folders", error);
+				Util.toast(SubsonicActivity.this, getErrorMessage(error));
+			}
+		}.execute();
 	}
 
 	public void toggleOffline() {

--- a/app/src/main/java/github/paroj/dsub2000/adapter/ArtistAdapter.java
+++ b/app/src/main/java/github/paroj/dsub2000/adapter/ArtistAdapter.java
@@ -16,15 +16,18 @@
 package github.paroj.dsub2000.adapter;
 
 import android.content.Context;
-import androidx.appcompat.widget.PopupMenu;
+import android.content.DialogInterface;
+import androidx.appcompat.app.AlertDialog;
 import android.view.LayoutInflater;
-import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.TextView;
 
 import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 import github.paroj.dsub2000.R;
 import github.paroj.dsub2000.domain.Artist;
@@ -41,17 +44,17 @@ public class ArtistAdapter extends SectionAdapter<Serializable> implements FastS
 	public static int VIEW_TYPE_ARTIST = 4;
 
 	private List<MusicFolder> musicFolders;
-	private OnMusicFolderChanged onMusicFolderChanged;
+	private OnMusicFoldersChanged onMusicFoldersChanged;
 
 	public ArtistAdapter(Context context, List<Serializable> artists, OnItemClickedListener listener) {
 		this(context, artists, null, listener, null);
 	}
 
-	public ArtistAdapter(Context context, List<Serializable> artists, List<MusicFolder> musicFolders, OnItemClickedListener onItemClickedListener, OnMusicFolderChanged onMusicFolderChanged) {
+	public ArtistAdapter(Context context, List<Serializable> artists, List<MusicFolder> musicFolders, OnItemClickedListener onItemClickedListener, OnMusicFoldersChanged onMusicFoldersChanged) {
 		super(context, artists);
 		this.musicFolders = musicFolders;
 		this.onItemClickedListener = onItemClickedListener;
-		this.onMusicFolderChanged = onMusicFolderChanged;
+		this.onMusicFoldersChanged = onMusicFoldersChanged;
 
 		if(musicFolders != null) {
 			this.singleSectionHeader = true;
@@ -64,51 +67,77 @@ public class ArtistAdapter extends SectionAdapter<Serializable> implements FastS
 		header.setOnClickListener(new View.OnClickListener() {
 			@Override
 			public void onClick(View v) {
-				PopupMenu popup = new PopupMenu(context, header.findViewById(R.id.select_artist_folder_2));
-
-				popup.getMenu().add(R.string.select_artist_all_folders);
-				for (MusicFolder musicFolder : musicFolders) {
-					popup.getMenu().add(musicFolder.getName());
-				}
-
-				popup.setOnMenuItemClickListener(new PopupMenu.OnMenuItemClickListener() {
-					@Override
-					public boolean onMenuItemClick(MenuItem item) {
-						for (MusicFolder musicFolder : musicFolders) {
-							if(item.getTitle().equals(musicFolder.getName())) {
-								if(onMusicFolderChanged != null) {
-									onMusicFolderChanged.onMusicFolderChanged(musicFolder);
-								}
-								return true;
-							}
-						}
-
-						if(onMusicFolderChanged != null) {
-							onMusicFolderChanged.onMusicFolderChanged(null);
-						}
-						return true;
-					}
-				});
-				popup.show();
+				showLibraryFilterDialog(context, musicFolders, onMusicFoldersChanged);
 			}
 		});
 
 		return new UpdateView.UpdateViewHolder(header, false);
 	}
+
+	public static void showLibraryFilterDialog(final Context context, final List<MusicFolder> musicFolders, final OnMusicFoldersChanged callback) {
+		if(musicFolders == null || musicFolders.isEmpty()) {
+			return;
+		}
+
+		final String[] names = new String[musicFolders.size()];
+		final boolean[] checked = new boolean[musicFolders.size()];
+		Set<String> selected = new HashSet<>(Util.getSelectedMusicFolderIds(context));
+		for(int i = 0; i < musicFolders.size(); i++) {
+			names[i] = musicFolders.get(i).getName();
+			checked[i] = selected.contains(musicFolders.get(i).getId());
+		}
+
+		new AlertDialog.Builder(context)
+			.setTitle(R.string.library_filter_dialog_title)
+			.setMultiChoiceItems(names, checked, new DialogInterface.OnMultiChoiceClickListener() {
+				@Override
+				public void onClick(DialogInterface dialog, int which, boolean isChecked) {
+					checked[which] = isChecked;
+				}
+			})
+			.setNeutralButton(R.string.select_artist_all_folders, new DialogInterface.OnClickListener() {
+				@Override
+				public void onClick(DialogInterface dialog, int which) {
+					if(callback != null) {
+						callback.onMusicFoldersChanged(new ArrayList<MusicFolder>());
+					}
+				}
+			})
+			.setPositiveButton(R.string.common_ok, new DialogInterface.OnClickListener() {
+				@Override
+				public void onClick(DialogInterface dialog, int which) {
+					List<MusicFolder> result = new ArrayList<>();
+					for(int i = 0; i < musicFolders.size(); i++) {
+						if(checked[i]) result.add(musicFolders.get(i));
+					}
+					if(callback != null) {
+						callback.onMusicFoldersChanged(result);
+					}
+				}
+			})
+			.setNegativeButton(R.string.common_cancel, null)
+			.show();
+	}
+
 	@Override
 	public void onBindHeaderHolder(UpdateView.UpdateViewHolder holder, String header, int sectionIndex) {
 		TextView folderName = (TextView) holder.getView().findViewById(R.id.select_artist_folder_2);
 
-		String musicFolderId = Util.getSelectedMusicFolderId(context);
-		if(musicFolderId != null) {
-			for (MusicFolder musicFolder : musicFolders) {
-				if (musicFolder.getId().equals(musicFolderId)) {
-					folderName.setText(musicFolder.getName());
+		List<String> selectedIds = Util.getSelectedMusicFolderIds(context);
+		if(selectedIds.isEmpty()) {
+			folderName.setText(R.string.select_artist_all_folders);
+		} else if(selectedIds.size() == 1) {
+			String only = selectedIds.get(0);
+			String resolved = only;
+			for(MusicFolder musicFolder : musicFolders) {
+				if(musicFolder.getId().equals(only)) {
+					resolved = musicFolder.getName();
 					break;
 				}
 			}
+			folderName.setText(resolved);
 		} else {
-			folderName.setText(R.string.select_artist_all_folders);
+			folderName.setText(context.getString(R.string.select_artist_n_folders, selectedIds.size()));
 		}
 	}
 
@@ -155,7 +184,7 @@ public class ArtistAdapter extends SectionAdapter<Serializable> implements FastS
 		}
 	}
 
-	public interface OnMusicFolderChanged {
-		void onMusicFolderChanged(MusicFolder musicFolder);
+	public interface OnMusicFoldersChanged {
+		void onMusicFoldersChanged(List<MusicFolder> selectedFolders);
 	}
 }

--- a/app/src/main/java/github/paroj/dsub2000/fragments/SelectArtistFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/SelectArtistFragment.java
@@ -33,7 +33,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.List;
 
-public class SelectArtistFragment extends SelectRecyclerFragment<Serializable> implements ArtistAdapter.OnMusicFolderChanged {
+public class SelectArtistFragment extends SelectRecyclerFragment<Serializable> implements ArtistAdapter.OnMusicFoldersChanged {
 	private static final String TAG = SelectArtistFragment.class.getSimpleName();
     private SelectArtistViewModel viewModel;
 	private List<MusicFolder> musicFolders = null;
@@ -251,12 +251,17 @@ public class SelectArtistFragment extends SelectRecyclerFragment<Serializable> i
 	}
 
 	@Override
-	public void onMusicFolderChanged(MusicFolder selectedFolder) {
-		String startMusicFolderId = Util.getSelectedMusicFolderId(context);
-		String musicFolderId = selectedFolder == null ? null : selectedFolder.getId();
+	public void onMusicFoldersChanged(List<MusicFolder> selectedFolders) {
+		List<String> previous = Util.getSelectedMusicFolderIds(context);
+		List<String> next = new ArrayList<>();
+		if(selectedFolders != null) {
+			for(MusicFolder folder : selectedFolders) {
+				next.add(folder.getId());
+			}
+		}
 
-		if(!Util.equals(startMusicFolderId, musicFolderId)) {
-			Util.setSelectedMusicFolderId(context, musicFolderId);
+		if(!previous.equals(next)) {
+			Util.setSelectedMusicFolderIds(context, next);
 			context.invalidate();
 		}
 	}

--- a/app/src/main/java/github/paroj/dsub2000/service/CachedMusicService.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/CachedMusicService.java
@@ -23,6 +23,7 @@ import java.io.IOException;
 import java.net.HttpURLConnection;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
@@ -81,7 +82,27 @@ public class CachedMusicService implements MusicService {
 	private final TimeLimitedCache<List<PodcastChannel>> cachedPodcastChannels = new TimeLimitedCache<List<PodcastChannel>>(10 * 3600, TimeUnit.SECONDS);
     private String restUrl;
 	private String musicFolderId;
+	private String musicFolderIdsKey;
 	private boolean isTagBrowsing = false;
+
+	/**
+	 * Stable per-server cache key for the currently selected set of music folders.
+	 * Empty list ("all folders") → null. One folder → that id (matches the legacy single-folder key).
+	 * Multiple folders → sorted ids joined with ",".
+	 */
+	private static String normalizeFolderIdsKey(List<String> folderIds) {
+		if(folderIds == null || folderIds.isEmpty()) {
+			return null;
+		}
+		List<String> sorted = new ArrayList<String>(folderIds);
+		Collections.sort(sorted);
+		StringBuilder sb = new StringBuilder();
+		for(int i = 0; i < sorted.size(); i++) {
+			if(i > 0) sb.append(',');
+			sb.append(sorted.get(i));
+		}
+		return sb.toString();
+	}
 
     public CachedMusicService(RESTMusicService musicService) {
         this.musicService = musicService;
@@ -148,14 +169,20 @@ public class CachedMusicService implements MusicService {
             cachedIndexes.clear();
             cachedMusicFolders.clear();
         }
+        // When the caller passes null but the user has selected multiple folders, the cache
+        // key is the joined ids set (matches the fan-out result produced by RESTMusicService).
+        String cacheKey = musicFolderId;
+        if(cacheKey == null) {
+            cacheKey = musicFolderIdsKey;
+        }
         Indexes result = null;
-		if(Util.equals(musicFolderId, this.musicFolderId)) {
+		if(Util.equals(cacheKey, this.musicFolderIdsKey)) {
 			result = cachedIndexes.get();
 		}
 
         if (result == null) {
 			String name = Util.isTagBrowsing(context, musicService.getInstance(context)) ? "artists" : "indexes";
-			name = getCacheName(context, name, musicFolderId);
+			name = getCacheName(context, name, cacheKey);
 			if(!refresh) {
 				result = FileUtil.deserialize(context, name, Indexes.class);
 			}
@@ -165,7 +192,7 @@ public class CachedMusicService implements MusicService {
             	FileUtil.serialize(context, result, name);
         	}
 
-			if(Util.equals(musicFolderId, this.musicFolderId)) {
+			if(Util.equals(cacheKey, this.musicFolderIdsKey)) {
 				cachedIndexes.set(result);
 			}
         }
@@ -1625,7 +1652,7 @@ public class CachedMusicService implements MusicService {
 		Indexes indexes;
 
 		IndexesUpdater(Context context, String name) {
-			super(context, name, Util.getSelectedMusicFolderId(context, musicService.getInstance(context)));
+			super(context, name, normalizeFolderIdsKey(Util.getSelectedMusicFolderIds(context, musicService.getInstance(context))));
 		}
 
 		@Override
@@ -1670,9 +1697,11 @@ public class CachedMusicService implements MusicService {
         }
 
 		String newMusicFolderId = Util.getSelectedMusicFolderId(context, instance);
-		if(!Util.equals(newMusicFolderId, musicFolderId)) {
+		String newMusicFolderIdsKey = normalizeFolderIdsKey(Util.getSelectedMusicFolderIds(context, instance));
+		if(!Util.equals(newMusicFolderIdsKey, musicFolderIdsKey)) {
 			cachedIndexes.clear();
 			musicFolderId = newMusicFolderId;
+			musicFolderIdsKey = newMusicFolderIdsKey;
 		}
     }
 

--- a/app/src/main/java/github/paroj/dsub2000/service/RESTMusicService.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/RESTMusicService.java
@@ -31,8 +31,15 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedList;
 import java.util.List;
+import java.util.Set;
+import java.util.concurrent.Callable;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -218,13 +225,25 @@ public class RESTMusicService implements MusicService {
 	}
 
     @Override
-    public Indexes getIndexes(String musicFolderId, boolean refresh, Context context, ProgressListener progressListener) throws Exception {
+    public Indexes getIndexes(final String musicFolderId, final boolean refresh, final Context context, final ProgressListener progressListener) throws Exception {
+        if(musicFolderId == null && REQUEST_FOLDER_OVERRIDE.get() == null) {
+            List<String> folderIds = Util.getSelectedMusicFolderIds(context, getInstance(context));
+            if(folderIds.size() > 1) {
+                return fanOutByFolder(folderIds, new Callable<Indexes>() {
+                    @Override public Indexes call() throws Exception {
+                        return getIndexes(REQUEST_FOLDER_OVERRIDE.get(), refresh, context, progressListener);
+                    }
+                }, INDEXES_MERGER);
+            }
+        }
+
         List<String> parameterNames = new ArrayList<String>();
         List<Object> parameterValues = new ArrayList<Object>();
 
-	if (musicFolderId != null) {
+        String effectiveFolderId = musicFolderId != null ? musicFolderId : REQUEST_FOLDER_OVERRIDE.get();
+        if (effectiveFolderId != null) {
             parameterNames.add("musicFolderId");
-            parameterValues.add(musicFolderId);
+            parameterValues.add(effectiveFolderId);
         }
 
         Reader reader = getReader(context, progressListener, Util.isTagBrowsing(context, getInstance(context)) ? "getArtists" : "getIndexes", parameterNames, parameterValues);
@@ -302,7 +321,17 @@ public class RESTMusicService implements MusicService {
 	}
 
 	@Override
-    public SearchResult search(SearchCritera critera, Context context, ProgressListener progressListener) throws Exception {
+    public SearchResult search(final SearchCritera critera, final Context context, final ProgressListener progressListener) throws Exception {
+        if(REQUEST_FOLDER_OVERRIDE.get() == null) {
+            List<String> folderIds = Util.getSelectedMusicFolderIds(context, getInstance(context));
+            if(folderIds.size() > 1) {
+                return fanOutByFolder(folderIds, new Callable<SearchResult>() {
+                    @Override public SearchResult call() throws Exception {
+                        return search(critera, context, progressListener);
+                    }
+                }, SEARCH_MERGER);
+            }
+        }
         try {
             return searchNew(critera, context, progressListener);
         } catch (ServerTooOldException x) {
@@ -331,10 +360,16 @@ public class RESTMusicService implements MusicService {
     private SearchResult searchNew(SearchCritera critera, Context context, ProgressListener progressListener) throws Exception {
         checkServerVersion(context, "1.4", null);
 
-        List<String> parameterNames = Arrays.asList("query", "artistCount", "albumCount", "songCount");
-        List<Object> parameterValues = Arrays.<Object>asList(critera.getQuery(), critera.getArtistCount(), critera.getAlbumCount(), critera.getSongCount());
+        int instance = getInstance(context);
+        List<String> parameterNames = new ArrayList<>(Arrays.asList("query", "artistCount", "albumCount", "songCount"));
+        List<Object> parameterValues = new ArrayList<Object>(Arrays.<Object>asList(critera.getQuery(), critera.getArtistCount(), critera.getAlbumCount(), critera.getSongCount()));
 
-		int instance = getInstance(context);
+        String folderId = resolveRequestFolderId(context, instance);
+        if(folderId != null) {
+            parameterNames.add("musicFolderId");
+            parameterValues.add(folderId);
+        }
+
 		String method;
 		if(ServerInfo.isMadsonic(context, instance) && ServerInfo.checkServerVersion(context, "2.0", instance)) {
 			if(Util.isTagBrowsing(context, instance)) {
@@ -550,7 +585,19 @@ public class RESTMusicService implements MusicService {
     }
 
     @Override
-    public MusicDirectory getAlbumList(String type, int size, int offset, boolean refresh, Context context, ProgressListener progressListener) throws Exception {
+    public MusicDirectory getAlbumList(final String type, final int size, final int offset, final boolean refresh, final Context context, final ProgressListener progressListener) throws Exception {
+		int instance = getInstance(context);
+		if(REQUEST_FOLDER_OVERRIDE.get() == null && Util.getAlbumListsPerFolder(context, instance)) {
+			List<String> folderIds = Util.getSelectedMusicFolderIds(context, instance);
+			if(folderIds.size() > 1) {
+				return fanOutByFolder(folderIds, new Callable<MusicDirectory>() {
+					@Override public MusicDirectory call() throws Exception {
+						return getAlbumList(type, size, offset, refresh, context, progressListener);
+					}
+				}, ENTRIES_MERGER);
+			}
+		}
+
 		List<String> names = new ArrayList<String>();
 		List<Object> values = new ArrayList<Object>();
 
@@ -562,9 +609,8 @@ public class RESTMusicService implements MusicService {
 		values.add(offset);
 
 		// Add folder if it was set and is non null
-		int instance = getInstance(context);
 		if(Util.getAlbumListsPerFolder(context, instance)) {
-			String folderId = Util.getSelectedMusicFolderId(context, instance);
+			String folderId = resolveRequestFolderId(context, instance);
 			if(folderId != null) {
 				names.add("musicFolderId");
 				values.add(folderId);
@@ -591,8 +637,20 @@ public class RESTMusicService implements MusicService {
     }
 
 	@Override
-	public MusicDirectory getAlbumList(String type, String extra, int size, int offset, boolean refresh, Context context, ProgressListener progressListener) throws Exception {
+	public MusicDirectory getAlbumList(final String type, final String extra, final int size, final int offset, final boolean refresh, final Context context, final ProgressListener progressListener) throws Exception {
 		checkServerVersion(context, "1.10.1", "This type of album list is not supported");
+
+		int instance = getInstance(context);
+		if(REQUEST_FOLDER_OVERRIDE.get() == null && Util.getAlbumListsPerFolder(context, instance)) {
+			List<String> folderIds = Util.getSelectedMusicFolderIds(context, instance);
+			if(folderIds.size() > 1) {
+				return fanOutByFolder(folderIds, new Callable<MusicDirectory>() {
+					@Override public MusicDirectory call() throws Exception {
+						return getAlbumList(type, extra, size, offset, refresh, context, progressListener);
+					}
+				}, ENTRIES_MERGER);
+			}
+		}
 
 		List<String> names = new ArrayList<String>();
 		List<Object> values = new ArrayList<Object>();
@@ -603,7 +661,6 @@ public class RESTMusicService implements MusicService {
 		values.add(size);
 		values.add(offset);
 
-		int instance = getInstance(context);
 		if("genres".equals(type)) {
 			names.add("type");
 			values.add("byGenre");
@@ -630,7 +687,7 @@ public class RESTMusicService implements MusicService {
 
 		// Add folder if it was set and is non null
 		if(Util.getAlbumListsPerFolder(context, instance)) {
-			String folderId = Util.getSelectedMusicFolderId(context, instance);
+			String folderId = resolveRequestFolderId(context, instance);
 			if(folderId != null) {
 				names.add("musicFolderId");
 				values.add(folderId);
@@ -732,14 +789,25 @@ public class RESTMusicService implements MusicService {
 	}
 
 	@Override
-    public MusicDirectory getStarredList(Context context, ProgressListener progressListener) throws Exception {
+    public MusicDirectory getStarredList(final Context context, final ProgressListener progressListener) throws Exception {
+		int instance = getInstance(context);
+		if(REQUEST_FOLDER_OVERRIDE.get() == null && Util.getAlbumListsPerFolder(context, instance)) {
+			List<String> folderIds = Util.getSelectedMusicFolderIds(context, instance);
+			if(folderIds.size() > 1) {
+				return fanOutByFolder(folderIds, new Callable<MusicDirectory>() {
+					@Override public MusicDirectory call() throws Exception {
+						return getStarredList(context, progressListener);
+					}
+				}, ENTRIES_MERGER);
+			}
+		}
+
 		List<String> names = new ArrayList<String>();
 		List<Object> values = new ArrayList<Object>();
 
 		// Add folder if it was set and is non null
-		int instance = getInstance(context);
 		if(Util.getAlbumListsPerFolder(context, instance)) {
-			String folderId = Util.getSelectedMusicFolderId(context, instance);
+			String folderId = resolveRequestFolderId(context, instance);
 			if(folderId != null) {
 				names.add("musicFolderId");
 				values.add(folderId);
@@ -766,7 +834,19 @@ public class RESTMusicService implements MusicService {
     }
 
     @Override
-    public MusicDirectory getRandomSongs(int size, Context context, ProgressListener progressListener) throws Exception {
+    public MusicDirectory getRandomSongs(final int size, final Context context, final ProgressListener progressListener) throws Exception {
+        int instance = getInstance(context);
+        if(REQUEST_FOLDER_OVERRIDE.get() == null && Util.getAlbumListsPerFolder(context, instance)) {
+            List<String> folderIds = Util.getSelectedMusicFolderIds(context, instance);
+            if(folderIds.size() > 1) {
+                return fanOutByFolder(folderIds, new Callable<MusicDirectory>() {
+                    @Override public MusicDirectory call() throws Exception {
+                        return getRandomSongs(size, context, progressListener);
+                    }
+                }, ENTRIES_MERGER);
+            }
+        }
+
         List<String> names = new ArrayList<String>();
         List<Object> values = new ArrayList<Object>();
 
@@ -774,9 +854,8 @@ public class RESTMusicService implements MusicService {
         values.add(size);
 
         // Add folder if it was set and is non null
-        int instance = getInstance(context);
         if(Util.getAlbumListsPerFolder(context, instance)) {
-            String folderId = Util.getSelectedMusicFolderId(context, instance);
+            String folderId = resolveRequestFolderId(context, instance);
             if(folderId != null) {
                 names.add("musicFolderId");
                 values.add(folderId);
@@ -1220,8 +1299,20 @@ public class RESTMusicService implements MusicService {
 	}
 
 	@Override
-	public MusicDirectory getSongsByGenre(String genre, int count, int offset, Context context, ProgressListener progressListener) throws Exception {
+	public MusicDirectory getSongsByGenre(final String genre, final int count, final int offset, final Context context, final ProgressListener progressListener) throws Exception {
 		checkServerVersion(context, "1.9", "Genres not supported.");
+
+		int instance = getInstance(context);
+		if(REQUEST_FOLDER_OVERRIDE.get() == null && Util.getAlbumListsPerFolder(context, instance)) {
+			List<String> folderIds = Util.getSelectedMusicFolderIds(context, instance);
+			if(folderIds.size() > 1) {
+				return fanOutByFolder(folderIds, new Callable<MusicDirectory>() {
+					@Override public MusicDirectory call() throws Exception {
+						return getSongsByGenre(genre, count, offset, context, progressListener);
+					}
+				}, ENTRIES_MERGER);
+			}
+		}
 
 		List<String> parameterNames = new ArrayList<String>();
 		List<Object> parameterValues = new ArrayList<Object>();
@@ -1234,9 +1325,8 @@ public class RESTMusicService implements MusicService {
 		parameterValues.add(offset);
 
 		// Add folder if it was set and is non null
-		int instance = getInstance(context);
 		if(Util.getAlbumListsPerFolder(context, instance)) {
-			String folderId = Util.getSelectedMusicFolderId(context, instance);
+			String folderId = resolveRequestFolderId(context, instance);
 			if(folderId != null) {
 				parameterNames.add("musicFolderId");
 				parameterValues.add(folderId);
@@ -2087,4 +2177,112 @@ public class RESTMusicService implements MusicService {
 	public HostnameVerifier getInsecureHostNameVerifier() {
 		return selfSignedHostnameVerifier;
 	}
+
+	// Library filter (multi-folder) fan-out support.
+	// When the user has selected >1 music folder, request methods that internally read the
+	// selected folder via Util.getSelectedMusicFolderId go through resolveRequestFolderId,
+	// which honours a ThreadLocal override set by fanOut* helpers below.
+	private static final ThreadLocal<String> REQUEST_FOLDER_OVERRIDE = new ThreadLocal<>();
+	private static final int FANOUT_MAX_PARALLEL = 4;
+
+	private String resolveRequestFolderId(Context context, int instance) {
+		String override = REQUEST_FOLDER_OVERRIDE.get();
+		if(override != null) {
+			return override;
+		}
+		return Util.getSelectedMusicFolderId(context, instance);
+	}
+
+	private interface Merger<T> {
+		void merge(T accumulator, T next);
+	}
+
+	private <T> T fanOutByFolder(List<String> folderIds, Callable<T> call, Merger<T> merger) throws Exception {
+		ExecutorService executor = Executors.newFixedThreadPool(Math.min(folderIds.size(), FANOUT_MAX_PARALLEL));
+		try {
+			List<Future<T>> futures = new ArrayList<>(folderIds.size());
+			for(final String folderId : folderIds) {
+				futures.add(executor.submit(new Callable<T>() {
+					@Override
+					public T call() throws Exception {
+						REQUEST_FOLDER_OVERRIDE.set(folderId);
+						try {
+							return call.call();
+						} finally {
+							REQUEST_FOLDER_OVERRIDE.remove();
+						}
+					}
+				}));
+			}
+
+			T accumulator = null;
+			for(Future<T> future : futures) {
+				T result;
+				try {
+					result = future.get();
+				} catch(ExecutionException e) {
+					Throwable cause = e.getCause();
+					if(cause instanceof Exception) {
+						throw (Exception) cause;
+					}
+					throw e;
+				}
+				if(accumulator == null) {
+					accumulator = result;
+				} else if(result != null) {
+					merger.merge(accumulator, result);
+				}
+			}
+			return accumulator;
+		} finally {
+			executor.shutdownNow();
+		}
+	}
+
+	private static final Merger<Indexes> INDEXES_MERGER = new Merger<Indexes>() {
+		@Override
+		public void merge(Indexes acc, Indexes next) {
+			mergeById(acc.getArtists(), next.getArtists());
+			mergeById(acc.getShortcuts(), next.getShortcuts());
+			mergeEntriesById(acc.getEntries(), next.getEntries());
+		}
+	};
+
+	private static void mergeById(List<Artist> into, List<Artist> from) {
+		if(into == null || from == null) return;
+		Set<String> seen = new HashSet<>();
+		for(Artist a : into) seen.add(a.getId());
+		for(Artist a : from) {
+			if(seen.add(a.getId())) into.add(a);
+		}
+	}
+
+	private static void mergeEntriesById(List<MusicDirectory.Entry> into, List<MusicDirectory.Entry> from) {
+		if(into == null || from == null) return;
+		Set<String> seen = new HashSet<>();
+		for(MusicDirectory.Entry e : into) seen.add(e.getId());
+		for(MusicDirectory.Entry e : from) {
+			if(seen.add(e.getId())) into.add(e);
+		}
+	}
+
+	private static final Merger<MusicDirectory> ENTRIES_MERGER = new Merger<MusicDirectory>() {
+		@Override
+		public void merge(MusicDirectory acc, MusicDirectory next) {
+			Set<String> seen = new HashSet<>();
+			for(MusicDirectory.Entry e : acc.getChildren()) seen.add(e.getId());
+			for(MusicDirectory.Entry e : next.getChildren()) {
+				if(seen.add(e.getId())) acc.addChild(e);
+			}
+		}
+	};
+
+	private static final Merger<SearchResult> SEARCH_MERGER = new Merger<SearchResult>() {
+		@Override
+		public void merge(SearchResult acc, SearchResult next) {
+			mergeById(acc.getArtists(), next.getArtists());
+			mergeEntriesById(acc.getAlbums(), next.getAlbums());
+			mergeEntriesById(acc.getSongs(), next.getSongs());
+		}
+	};
 }

--- a/app/src/main/java/github/paroj/dsub2000/util/Constants.java
+++ b/app/src/main/java/github/paroj/dsub2000/util/Constants.java
@@ -85,6 +85,7 @@ public final class Constants {
 	public static final String PREFERENCES_KEY_TEST_CONNECTION = "serverTestConnection";
 	public static final String PREFERENCES_KEY_OPEN_BROWSER = "openBrowser";
     public static final String PREFERENCES_KEY_MUSIC_FOLDER_ID = "musicFolderId";
+    public static final String PREFERENCES_KEY_MUSIC_FOLDER_IDS = "musicFolderIds";
     public static final String PREFERENCES_KEY_USERNAME = "username";
     public static final String PREFERENCES_KEY_PASSWORD = "password";
 	public static final String PREFERENCES_KEY_SERVER_AUTHHEADER = "authHeader";

--- a/app/src/main/java/github/paroj/dsub2000/util/Util.java
+++ b/app/src/main/java/github/paroj/dsub2000/util/Util.java
@@ -241,19 +241,55 @@ public final class Util {
     }
 
     public static void setSelectedMusicFolderId(Context context, String musicFolderId) {
-        int instance = getActiveServer(context);
-        SharedPreferences prefs = getPreferences(context);
-        SharedPreferences.Editor editor = prefs.edit();
-        editor.putString(Constants.PREFERENCES_KEY_MUSIC_FOLDER_ID + instance, musicFolderId);
-        editor.commit();
+        setSelectedMusicFolderIds(context, musicFolderId == null ? new ArrayList<String>() : new ArrayList<>(Arrays.asList(musicFolderId)));
     }
 
     public static String getSelectedMusicFolderId(Context context) {
         return getSelectedMusicFolderId(context, getActiveServer(context));
     }
 	public static String getSelectedMusicFolderId(Context context, int instance) {
+		List<String> ids = getSelectedMusicFolderIds(context, instance);
+		return ids.size() == 1 ? ids.get(0) : null;
+	}
+
+	public static List<String> getSelectedMusicFolderIds(Context context) {
+		return getSelectedMusicFolderIds(context, getActiveServer(context));
+	}
+	public static List<String> getSelectedMusicFolderIds(Context context, int instance) {
 		SharedPreferences prefs = getPreferences(context);
-		return prefs.getString(Constants.PREFERENCES_KEY_MUSIC_FOLDER_ID + instance, null);
+		String joined = prefs.getString(Constants.PREFERENCES_KEY_MUSIC_FOLDER_IDS + instance, null);
+		if(joined == null) {
+			// Migrate legacy single-folder key
+			String legacy = prefs.getString(Constants.PREFERENCES_KEY_MUSIC_FOLDER_ID + instance, null);
+			if(legacy == null) {
+				return new ArrayList<>();
+			}
+			List<String> migrated = new ArrayList<>();
+			migrated.add(legacy);
+			return migrated;
+		}
+		if(joined.isEmpty()) {
+			return new ArrayList<>();
+		}
+		return new ArrayList<>(Arrays.asList(joined.split(",")));
+	}
+	public static void setSelectedMusicFolderIds(Context context, List<String> musicFolderIds) {
+		int instance = getActiveServer(context);
+		SharedPreferences prefs = getPreferences(context);
+		SharedPreferences.Editor editor = prefs.edit();
+		if(musicFolderIds == null || musicFolderIds.isEmpty()) {
+			editor.putString(Constants.PREFERENCES_KEY_MUSIC_FOLDER_IDS + instance, "");
+			editor.putString(Constants.PREFERENCES_KEY_MUSIC_FOLDER_ID + instance, null);
+		} else {
+			StringBuilder sb = new StringBuilder();
+			for(int i = 0; i < musicFolderIds.size(); i++) {
+				if(i > 0) sb.append(',');
+				sb.append(musicFolderIds.get(i));
+			}
+			editor.putString(Constants.PREFERENCES_KEY_MUSIC_FOLDER_IDS + instance, sb.toString());
+			editor.putString(Constants.PREFERENCES_KEY_MUSIC_FOLDER_ID + instance, musicFolderIds.size() == 1 ? musicFolderIds.get(0) : null);
+		}
+		editor.commit();
 	}
 
 	public static boolean getAlbumListsPerFolder(Context context) {

--- a/app/src/main/res/menu/drawer_navigation.xml
+++ b/app/src/main/res/menu/drawer_navigation.xml
@@ -48,6 +48,9 @@
 		android:id="@+id/drawer_bottom"
 		android:checkableBehavior="single">
 
+		<item android:id="@+id/drawer_library_filter"
+			  android:title="@string/menu.library_filter"/>
+
 		<item android:id="@+id/drawer_offline"
 			  android:title="@string/button_bar.offline"/>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -591,6 +591,9 @@
 
 	<string name="select_artist.folder">Select folder</string>
     <string name="select_artist.all_folders">All folders</string>
+    <string name="select_artist.n_folders">%d libraries</string>
+    <string name="menu.library_filter">Library filter</string>
+    <string name="library_filter.dialog_title">Filter libraries</string>
 
     <string name="equalizer.label">Equalizer</string>
     <string name="equalizer.enabled">Enabled</string>


### PR DESCRIPTION
Lets users select multiple Subsonic music folders at once; Artists, album lists, search, starred, random songs and genre browsing fan out across the selected set and merge results client-side (the API only accepts one musicFolderId per call). A new "Library filter" entry in the nav drawer opens the same multi-choice picker as the Artists tab header, and only shows up when the server exposes >1 folder.

Closes: #140 