### PR TITLE
Add reverse sort option for podcast episode lists

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/fragments/SelectDirectoryFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/SelectDirectoryFragment.java
@@ -71,6 +71,7 @@ import github.paroj.dsub2000.viewmodel.SelectDirectoryViewModel;
 
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashSet;
 import java.util.Set;
 
@@ -278,6 +279,12 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 						menu.removeItem(R.id.menu_download_all);
 					}
 				}
+
+				MenuItem reverseItem = menu.findItem(R.id.menu_reverse_sort);
+				if(reverseItem != null) {
+					reverseItem.setChecked(Util.getPreferences(context)
+						.getBoolean(Constants.PREFERENCES_KEY_REVERSE_PODCAST_SORT, false));
+				}
 			}
 		}
 
@@ -306,6 +313,16 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 				return true;
 			case R.id.menu_radio:
 				startArtistRadio(id);
+				return true;
+			case R.id.menu_reverse_sort:
+				SharedPreferences prefs = Util.getPreferences(context);
+				boolean newValue = !prefs.getBoolean(Constants.PREFERENCES_KEY_REVERSE_PODCAST_SORT, false);
+				prefs.edit().putBoolean(Constants.PREFERENCES_KEY_REVERSE_PODCAST_SORT, newValue).apply();
+				item.setChecked(newValue);
+				Collections.reverse(entries);
+				if(entryGridAdapter != null) {
+					entryGridAdapter.notifyDataSetChanged();
+				}
 				return true;
 		}
 
@@ -706,6 +723,11 @@ public class SelectDirectoryFragment extends SubsonicFragment implements Section
 
 		if(validData) {
 			recyclerView.setVisibility(View.VISIBLE);
+		}
+
+		if(podcastId != null && !entries.isEmpty()
+				&& Util.getPreferences(context).getBoolean(Constants.PREFERENCES_KEY_REVERSE_PODCAST_SORT, false)) {
+			Collections.reverse(entries);
 		}
 
 		if(albumListType == null || albumListType.startsWith("starred")) {

--- a/app/src/main/java/github/paroj/dsub2000/util/Constants.java
+++ b/app/src/main/java/github/paroj/dsub2000/util/Constants.java
@@ -145,6 +145,7 @@ public final class Constants {
 	public static final String PREFERENCES_KEY_BOOKMARKS_ENABLED = "bookmarksEnabled";
 	public static final String PREFERENCES_KEY_INTERNET_RADIO_ENABLED = "internetRadioEnabled";
 	public static final String PREFERENCES_KEY_CUSTOM_SORT_ENABLED = "customSortEnabled";
+	public static final String PREFERENCES_KEY_REVERSE_PODCAST_SORT = "reversePodcastSort";
 	public static final String PREFERENCES_KEY_MENU_PLAY_NOW = "showPlayNow";
 	public static final String PREFERENCES_KEY_MENU_PLAY_SHUFFLED = "showPlayShuffled";
 	public static final String PREFERENCES_KEY_MENU_PLAY_NEXT = "showPlayNext";

--- a/app/src/main/res/menu/select_podcast_episode.xml
+++ b/app/src/main/res/menu/select_podcast_episode.xml
@@ -14,7 +14,13 @@
 		android:id="@+id/menu_download_all"
 		android:title="@string/select_podcasts.server_download"/>
 
-	<item 
+	<item
 		android:id="@+id/menu_delete"
 		android:title="@string/menu.delete_cache"/>
+
+	<item
+		android:id="@+id/menu_reverse_sort"
+		android:title="@string/menu.reverse_sort"
+		android:checkable="true"
+		compat:showAsAction="never"/>
 </menu>

--- a/app/src/main/res/menu/select_podcast_episode_offline.xml
+++ b/app/src/main/res/menu/select_podcast_episode_offline.xml
@@ -1,7 +1,13 @@
 <?xml version="1.0" encoding="utf-8"?>
 <menu xmlns:android="http://schemas.android.com/apk/res/android"
 		xmlns:compat="http://schemas.android.com/apk/res-auto">
-	<item 
+	<item
 		android:id="@+id/menu_delete"
 		android:title="@string/menu.delete_cache"/>
+
+	<item
+		android:id="@+id/menu_reverse_sort"
+		android:title="@string/menu.reverse_sort"
+		android:checkable="true"
+		compat:showAsAction="never"/>
 </menu>

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -90,6 +90,7 @@
 	<string name="menu.search">Search</string>
 	<string name="menu.shuffle">Shuffle</string>
 	<string name="menu.refresh">Refresh</string>
+	<string name="menu.reverse_sort">Newest first</string>
 	<string name="menu.play">Play</string>
 	<string name="menu.play_last">Play Last</string>
     <string name="menu.exit">Exit</string>


### PR DESCRIPTION
Closes #124

  ## Summary

  Adds a "Newest first" toggle to the podcast episode list overflow menu. By default Subsonic returns episodes in publication order (oldest → newest), which is
  inconvenient for podcasts with hundreds of episodes — the user has to scroll to the bottom every time to reach the latest one. The new toggle reverses the list
   so the newest episode sits at the top.

  The toggle is a single global preference (reversePodcastSort), persisted via SharedPreferences alongside the existing customSortEnabled key. When
  changed, the visible list flips in place — no server round-trip — and the new order is applied automatically every time a podcast view is opened.

  Scope is intentionally limited to podcast episode views (podcastId != null in SelectDirectoryFragment); regular album track lists are untouched and
  continue to sort by disc/track number.