### PR TITLE
Don't auto-resume playback on Bluetooth/headset connect

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/receiver/MediaButtonIntentReceiver.java
+++ b/app/src/main/java/github/paroj/dsub2000/receiver/MediaButtonIntentReceiver.java
@@ -36,16 +36,20 @@ public class MediaButtonIntentReceiver extends BroadcastReceiver {
     @Override
     public void onReceive(Context context, Intent intent) {
         KeyEvent event = (KeyEvent) intent.getParcelableExtra(Intent.EXTRA_KEY_EVENT);
-		if(DownloadService.getInstance() == null && event != null && (event.getKeyCode() == KeyEvent.KEYCODE_MEDIA_STOP ||
-			event.getKeyCode() == KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE || event.getKeyCode() == KeyEvent.KEYCODE_HEADSETHOOK)) {
-			Log.w(TAG, "Ignore keycode event because downloadService is off");
+
+		if (event == null) {
+			// Android delivers a MEDIA_BUTTON broadcast with no key event when a Bluetooth
+			// device connects to the last active media app. Don't auto-resume from here —
+			// the user did not press anything.
+			Log.i(TAG, "Ignoring MEDIA_BUTTON broadcast with no key event");
 			return;
 		}
 
-		if (event == null) {
-			// we only get here, if DownloadService was dead, so we can assume it was not playing 
-			Log.i(TAG, "Got null MEDIA_BUTTON key event, assuming play button pressed");
-			event = new KeyEvent(KeyEvent.ACTION_UP, KeyEvent.KEYCODE_MEDIA_PLAY);
+		if(DownloadService.getInstance() == null && (event.getKeyCode() == KeyEvent.KEYCODE_MEDIA_STOP ||
+			event.getKeyCode() == KeyEvent.KEYCODE_MEDIA_PLAY_PAUSE || event.getKeyCode() == KeyEvent.KEYCODE_HEADSETHOOK ||
+			event.getKeyCode() == KeyEvent.KEYCODE_MEDIA_PLAY)) {
+			Log.w(TAG, "Ignore keycode event because downloadService is off");
+			return;
 		}
 
         Log.i(TAG, "Got MEDIA_BUTTON key event: " + event);

--- a/app/src/main/java/github/paroj/dsub2000/service/DownloadService.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/DownloadService.java
@@ -164,6 +164,9 @@ public class DownloadService extends Service {
 	private final CopyOnWriteArrayList<OnSongChangedListener> onSongChangedListeners = new CopyOnWriteArrayList<>();
 	private long revision;
 	private static DownloadService instance;
+	private android.media.AudioDeviceCallback audioDeviceCallback;
+	private volatile long lastAudioRouteAddTime;
+	private static final long BT_AUTORESUME_WINDOW_MS = 3000;
 	private String suggestedPlaylistName;
 	private String suggestedPlaylistId;
 	private PowerManager.WakeLock wakeLock;
@@ -316,9 +319,39 @@ public class DownloadService extends Service {
 		artistRadioBuffer = new ArtistRadioBuffer(this);
 		lifecycleSupport.onCreate();
 
+		registerAudioRouteCallback();
+
 		if(Build.VERSION.SDK_INT >= 26) {
 			Notifications.shutGoogleUpNotification(this);
 		}
+	}
+
+	private void registerAudioRouteCallback() {
+		// Mark when a new audio output device appears (e.g. Bluetooth A2DP, wired headset).
+		// Used to recognise the synthetic play command Android delivers right after a
+		// Bluetooth connect (see isLikelyBluetoothAutoResume).
+		final AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+		audioDeviceCallback = new android.media.AudioDeviceCallback() {
+			@Override
+			public void onAudioDevicesAdded(android.media.AudioDeviceInfo[] addedDevices) {
+				for (android.media.AudioDeviceInfo d : addedDevices) {
+					int type = d.getType();
+					if (type == android.media.AudioDeviceInfo.TYPE_BLUETOOTH_A2DP
+							|| type == android.media.AudioDeviceInfo.TYPE_BLUETOOTH_SCO
+							|| type == android.media.AudioDeviceInfo.TYPE_WIRED_HEADSET
+							|| type == android.media.AudioDeviceInfo.TYPE_WIRED_HEADPHONES
+							|| type == android.media.AudioDeviceInfo.TYPE_USB_HEADSET) {
+						lastAudioRouteAddTime = System.currentTimeMillis();
+						break;
+					}
+				}
+			}
+		};
+		audioManager.registerAudioDeviceCallback(audioDeviceCallback, null);
+	}
+
+	public boolean isLikelyBluetoothAutoResume() {
+		return (System.currentTimeMillis() - lastAudioRouteAddTime) < BT_AUTORESUME_WINDOW_MS;
 	}
 
 	@Override
@@ -358,6 +391,12 @@ public class DownloadService extends Service {
 	public void onDestroy() {
 		super.onDestroy();
 		instance = null;
+
+		if (audioDeviceCallback != null) {
+			AudioManager audioManager = (AudioManager) getSystemService(Context.AUDIO_SERVICE);
+			audioManager.unregisterAudioDeviceCallback(audioDeviceCallback);
+			audioDeviceCallback = null;
+		}
 
 		if(currentPlaying != null) currentPlaying.setPlaying(false);
 		if(sleepTimer != null){
@@ -2951,7 +2990,9 @@ public class DownloadService extends Service {
 	}
 
 	public void handleKeyEvent(KeyEvent keyEvent) {
-		lifecycleSupport.handleKeyEvent(keyEvent);
+		// Called from RemoteControlClientLP.onMediaButtonEvent — this is the system MEDIA_BUTTON
+		// path (incl. Bluetooth synthetic play), so mark as untrusted.
+		lifecycleSupport.handleKeyEvent(keyEvent, true);
 	}
 
 	public void addOnSongChangedListener(OnSongChangedListener listener) {

--- a/app/src/main/java/github/paroj/dsub2000/service/DownloadServiceLifecycleSupport.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/DownloadServiceLifecycleSupport.java
@@ -246,7 +246,11 @@ public class DownloadServiceLifecycleSupport {
 					} else if(intent.getExtras() != null) {
 						final KeyEvent event = (KeyEvent) intent.getExtras().get(Intent.EXTRA_KEY_EVENT);
 						if (event != null) {
-							handleKeyEvent(event);
+							// Notification action PendingIntents set a custom action string ("KEYCODE_MEDIA_*").
+							// MediaButtonIntentReceiver forwards system MEDIA_BUTTON broadcasts with no action.
+							// Only the latter can be a synthetic Bluetooth-connect "play".
+							boolean fromMediaButton = (action == null);
+							handleKeyEvent(event, fromMediaButton);
 						}
 					}
 				}
@@ -388,6 +392,12 @@ public class DownloadServiceLifecycleSupport {
 	}
 
 	public void handleKeyEvent(KeyEvent event) {
+		// Default to trusted (notification taps, in-app calls) — only the system MEDIA_BUTTON path
+		// passes false explicitly. Callers from RemoteControlClientLP.onMediaButtonEvent pass true.
+		handleKeyEvent(event, false);
+	}
+
+	public void handleKeyEvent(KeyEvent event, boolean fromMediaButton) {
 		if(event.getAction() == KeyEvent.ACTION_DOWN && event.getRepeatCount() > 0) {
 			switch (event.getKeyCode()) {
 				case RemoteControlClient.FLAG_KEY_MEDIA_PREVIOUS:
@@ -440,7 +450,17 @@ public class DownloadServiceLifecycleSupport {
 				case RemoteControlClient.FLAG_KEY_MEDIA_PLAY:
 				case KeyEvent.KEYCODE_MEDIA_PLAY:
 					if(downloadService.getPlayerState() != PlayerState.STARTED) {
-						downloadService.start();
+						// Suppress only the synthetic MEDIA_PLAY that arrives via the system
+						// MEDIA_BUTTON path right after a Bluetooth/headset connect.
+						PlayerState state = downloadService.getPlayerState();
+						boolean btAuto = fromMediaButton && state != PlayerState.PAUSED_TEMP
+								&& downloadService.isLikelyBluetoothAutoResume()
+								&& !Util.getPreferences(downloadService).getBoolean(Constants.PREFERENCES_KEY_RESUME_ON_BLUETOOTH, false);
+						if (btAuto) {
+							Log.i(TAG, "Ignoring MEDIA_PLAY key (state=" + state + ") — Bluetooth auto-resume");
+						} else {
+							downloadService.start();
+						}
 					}
 					break;
 				case RemoteControlClient.FLAG_KEY_MEDIA_PAUSE:

--- a/app/src/main/java/github/paroj/dsub2000/util/Constants.java
+++ b/app/src/main/java/github/paroj/dsub2000/util/Constants.java
@@ -115,6 +115,7 @@ public final class Constants {
 	public static final String PREFERENCES_KEY_SLEEP_TIMER_DURATION = "sleepTimerDuration";
 	public static final String PREFERENCES_KEY_OFFLINE = "offline";
 	public static final String PREFERENCES_KEY_TEMP_LOSS = "tempLoss";
+	public static final String PREFERENCES_KEY_RESUME_ON_BLUETOOTH = "resumeOnBluetooth";
 	public static final String PREFERENCES_KEY_SHUFFLE_START_YEAR = "startYear";
 	public static final String PREFERENCES_KEY_SHUFFLE_END_YEAR = "endYear";
 	public static final String PREFERENCES_KEY_SHUFFLE_GENRE = "genre";

--- a/app/src/main/java/github/paroj/dsub2000/util/compat/RemoteControlClientLP.java
+++ b/app/src/main/java/github/paroj/dsub2000/util/compat/RemoteControlClientLP.java
@@ -47,6 +47,7 @@ import github.paroj.dsub2000.activity.SubsonicActivity;
 import github.paroj.dsub2000.activity.SubsonicFragmentActivity;
 import github.paroj.dsub2000.domain.Bookmark;
 import github.paroj.dsub2000.domain.MusicDirectory;
+import github.paroj.dsub2000.domain.PlayerState;
 import github.paroj.dsub2000.domain.MusicDirectory.Entry;
 import github.paroj.dsub2000.domain.Playlist;
 import github.paroj.dsub2000.domain.SearchCritera;
@@ -481,6 +482,17 @@ public class RemoteControlClientLP extends RemoteControlClientBase {
 	private class EventCallback extends MediaSessionCompat.Callback {
 		@Override
 		public void onPlay() {
+			// Suppress only the synthetic play command Android delivers right after a
+			// Bluetooth/headset connect. Explicit user taps (notification, lockscreen, Auto)
+			// arrive outside that short window and behave as before.
+			PlayerState state = downloadService.getPlayerState();
+			if (state != PlayerState.PAUSED_TEMP && downloadService.isLikelyBluetoothAutoResume()) {
+				SharedPreferences prefs = Util.getPreferences(downloadService);
+				if (!prefs.getBoolean(Constants.PREFERENCES_KEY_RESUME_ON_BLUETOOTH, false)) {
+					Log.i(TAG, "Ignoring MediaSession onPlay (state=" + state + ") — Bluetooth auto-resume");
+					return;
+				}
+			}
 			downloadService.start();
 		}
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -393,6 +393,8 @@
 	<string name="settings.temp_loss_pause_lower">Pause, lower volume when requested</string>
 	<string name="settings.temp_loss_lower">Always lower volume</string>
 	<string name="settings.temp_loss_nothing">Do Nothing</string>
+	<string name="settings.resume_on_bluetooth_title">Resume on Bluetooth connect</string>
+	<string name="settings.resume_on_bluetooth_summary">Automatically resume playback when a Bluetooth device connects, even if you explicitly paused or stopped</string>
 	<string name="settings.keep_played_count_title">Keep played songs</string>
 	<string name="settings.keep_played_count_none">Remove all played songs</string>
 	<string name="settings.keep_played_count_one">Keep last played song</string>

--- a/app/src/main/res/xml/settings_playback.xml
+++ b/app/src/main/res/xml/settings_playback.xml
@@ -36,6 +36,12 @@
 			android:entries="@array/disconnectPauseNames"/>
 
 		<CheckBoxPreference
+			android:title="@string/settings.resume_on_bluetooth_title"
+			android:summary="@string/settings.resume_on_bluetooth_summary"
+			android:key="resumeOnBluetooth"
+			android:defaultValue="false"/>
+
+		<CheckBoxPreference
 			android:title="@string/settings.persistent_title"
 			android:summary="@string/settings.persistent_summary"
 			android:key="persistentNotification"


### PR DESCRIPTION
Fixes issue #133: DSub was resuming the queue whenever a Bluetooth device connected, even when the user had explicitly paused or stopped playback (and even when the service had been force-stopped).

Three sources of the unwanted resume:

  1. MediaButtonIntentReceiver synthesized a KEYCODE_MEDIA_PLAY when the broadcast arrived with a null KeyEvent — exactly what Android delivers to the last active media app on Bluetooth connect. The synthesis is removed; null events are now ignored.

  2. MediaSession.Callback.onPlay() called downloadService.start() unconditionally. Likewise the KEYCODE_MEDIA_PLAY case in handleKeyEvent. Both are suppressed only when an audio output device was added in the last 3 seconds (tracked via AudioDeviceCallback). This catches the synthetic Bluetooth play without affecting explicit user taps in the notification, lockscreen, or Android Auto.

  3. PAUSED_TEMP (transient audio focus loss, e.g. a phone call) continues to auto-resume as before.

A new "Resume on Bluetooth connect" preference (default off) lets users restore the old behaviour if they want it.