### PR TITLE
Add entire-library caching support

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -19,6 +19,7 @@ android {
 		resValue 'string', 'provider.podcast', applicationId + ".podcasts.provider"
 		resValue 'string', 'provider.starred', applicationId + ".starred.provider"
 		resValue 'string', 'provider.recently_added', applicationId + ".mostrecent.provider"
+		resValue 'string', 'provider.library', applicationId + ".library.provider"
 		signingConfig signingConfigs.debug
 		testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 	}

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -172,6 +172,17 @@
 			<meta-data android:name="android.content.SyncAdapter"
 					   android:resource="@xml/mostrecent_syncadapter" />
 		</service>
+		<service android:name="github.paroj.dsub2000.service.sync.LibrarySyncService"
+			     android:foregroundServiceType="dataSync|mediaPlayback"
+				 android:exported="true"
+				 android:process=":sync">
+
+			<intent-filter>
+				<action android:name="android.content.SyncAdapter"/>
+			</intent-filter>
+			<meta-data android:name="android.content.SyncAdapter"
+					   android:resource="@xml/library_syncadapter" />
+		</service>
 
 		<service android:name="github.paroj.dsub2000.service.HeadphoneListenerService"
 			android:foregroundServiceType="mediaPlayback"
@@ -275,6 +286,11 @@
 		<provider android:name="github.paroj.dsub2000.provider.MostRecentStubProvider"
 				  android:authorities="@string/provider.recently_added"
 				  android:label="@string/main.albums_newest"
+				  android:exported="false"
+				  android:syncable="true"/>
+		<provider android:name="github.paroj.dsub2000.provider.LibraryStubProvider"
+				  android:authorities="@string/provider.library"
+				  android:label="@string/settings.sync_library"
 				  android:exported="false"
 				  android:syncable="true"/>
 

--- a/app/src/main/java/github/paroj/dsub2000/activity/SubsonicFragmentActivity.java
+++ b/app/src/main/java/github/paroj/dsub2000/activity/SubsonicFragmentActivity.java
@@ -928,6 +928,8 @@ public class SubsonicFragmentActivity extends SubsonicActivity implements Downlo
 				ContentResolver.addPeriodicSync(account, Constants.SYNC_ACCOUNT_STARRED_AUTHORITY, new Bundle(), 60L * syncInterval);
 				ContentResolver.setSyncAutomatically(account, Constants.SYNC_ACCOUNT_MOST_RECENT_AUTHORITY, (syncEnabled && prefs.getBoolean(Constants.PREFERENCES_KEY_SYNC_MOST_RECENT, false)));
 				ContentResolver.addPeriodicSync(account, Constants.SYNC_ACCOUNT_MOST_RECENT_AUTHORITY, new Bundle(), 60L * syncInterval);
+				ContentResolver.setSyncAutomatically(account, Constants.SYNC_ACCOUNT_LIBRARY_AUTHORITY, (syncEnabled && prefs.getBoolean(Constants.PREFERENCES_KEY_SYNC_LIBRARY, false)));
+				ContentResolver.addPeriodicSync(account, Constants.SYNC_ACCOUNT_LIBRARY_AUTHORITY, new Bundle(), 60L * syncInterval);
 				return null;
 			}
 

--- a/app/src/main/java/github/paroj/dsub2000/fragments/SettingsFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/SettingsFragment.java
@@ -99,6 +99,7 @@ public class SettingsFragment extends PreferenceCompatFragment implements Shared
 	private CheckBoxPreference syncNotification;
 	private CheckBoxPreference syncStarred;
 	private CheckBoxPreference syncMostRecent;
+	private CheckBoxPreference syncLibrary;
 	private CheckBoxPreference replayGain;
 	private ListPreference replayGainType;
 	private Preference replayGainBump;
@@ -282,6 +283,7 @@ public class SettingsFragment extends PreferenceCompatFragment implements Shared
 		syncNotification = (CheckBoxPreference) this.findPreference(Constants.PREFERENCES_KEY_SYNC_NOTIFICATION);
 		syncStarred = (CheckBoxPreference) this.findPreference(Constants.PREFERENCES_KEY_SYNC_STARRED);
 		syncMostRecent = (CheckBoxPreference) this.findPreference(Constants.PREFERENCES_KEY_SYNC_MOST_RECENT);
+		syncLibrary = (CheckBoxPreference) this.findPreference(Constants.PREFERENCES_KEY_SYNC_LIBRARY);
 		replayGain = (CheckBoxPreference) this.findPreference(Constants.PREFERENCES_KEY_REPLAY_GAIN);
 		replayGainType = (ListPreference) this.findPreference(Constants.PREFERENCES_KEY_REPLAY_GAIN_TYPE);
 		replayGainBump = this.findPreference(Constants.PREFERENCES_KEY_REPLAY_GAIN_BUMP);
@@ -488,6 +490,7 @@ public class SettingsFragment extends PreferenceCompatFragment implements Shared
 					syncNotification.setEnabled(true);
 					syncStarred.setEnabled(true);
 					syncMostRecent.setEnabled(true);
+					syncLibrary.setEnabled(true);
 				}
 			} else {
 				if(syncInterval.isEnabled()) {
@@ -496,6 +499,7 @@ public class SettingsFragment extends PreferenceCompatFragment implements Shared
 					syncNotification.setEnabled(false);
 					syncStarred.setEnabled(false);
 					syncMostRecent.setEnabled(false);
+					syncLibrary.setEnabled(false);
 				}
 			}
 		}

--- a/app/src/main/java/github/paroj/dsub2000/provider/LibraryStubProvider.java
+++ b/app/src/main/java/github/paroj/dsub2000/provider/LibraryStubProvider.java
@@ -1,0 +1,55 @@
+/*
+ This file is part of Subsonic.
+
+ Subsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Subsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Subsonic.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package github.paroj.dsub2000.provider;
+
+import android.content.ContentProvider;
+import android.content.ContentValues;
+import android.database.Cursor;
+import android.net.Uri;
+
+public class LibraryStubProvider extends ContentProvider {
+    @Override
+    public boolean onCreate() {
+        return true;
+    }
+
+    @Override
+    public Cursor query(Uri uri, String[] projection, String selection, String[] selectionArgs, String sortOrder) {
+        return null;
+    }
+
+    @Override
+    public String getType(Uri uri) {
+        return "";
+    }
+
+    @Override
+    public Uri insert(Uri uri, ContentValues values) {
+        return null;
+    }
+
+    @Override
+    public int delete(Uri uri, String selection, String[] selectionArgs) {
+        return 0;
+    }
+
+    @Override
+    public int update(Uri uri, ContentValues values, String selection, String[] selectionArgs) {
+        return 0;
+    }
+}

--- a/app/src/main/java/github/paroj/dsub2000/service/sync/LibrarySyncAdapter.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/sync/LibrarySyncAdapter.java
@@ -1,0 +1,87 @@
+/*
+ This file is part of Subsonic.
+
+ Subsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Subsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Subsonic.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package github.paroj.dsub2000.service.sync;
+
+import android.annotation.TargetApi;
+import android.content.Context;
+import android.util.Log;
+
+import java.io.File;
+import java.util.ArrayList;
+
+import github.paroj.dsub2000.R;
+import github.paroj.dsub2000.domain.Artist;
+import github.paroj.dsub2000.domain.Indexes;
+import github.paroj.dsub2000.domain.MusicDirectory;
+import github.paroj.dsub2000.util.FileUtil;
+import github.paroj.dsub2000.util.Notifications;
+import github.paroj.dsub2000.util.SyncUtil;
+import github.paroj.dsub2000.util.Util;
+
+public class LibrarySyncAdapter extends SubsonicSyncAdapter {
+	private static String TAG = LibrarySyncAdapter.class.getSimpleName();
+
+	public LibrarySyncAdapter(Context context, boolean autoInitialize) {
+		super(context, autoInitialize);
+	}
+	@TargetApi(14)
+	public LibrarySyncAdapter(Context context, boolean autoInitialize, boolean allowParallelSyncs) {
+		super(context, autoInitialize, allowParallelSyncs);
+	}
+
+	@Override
+	public void onExecuteSync(Context context, int instance) throws NetworkNotValidException {
+		try {
+			ArrayList<String> syncedList = new ArrayList<String>();
+
+			String musicFolderId = Util.getSelectedMusicFolderId(context, instance);
+			Indexes indexes = musicService.getIndexes(musicFolderId, true, context, null);
+
+			// Build a virtual root directory whose children are all top-level artists
+			// (and any loose top-level songs). downloadRecursively will then walk each
+			// artist via getMusicDirectory(Entry), which already handles tag vs folder
+			// browsing in the base class.
+			MusicDirectory root = new MusicDirectory();
+			for (Artist artist : indexes.getShortcuts()) {
+				root.addChild(new MusicDirectory.Entry(artist));
+			}
+			for (Artist artist : indexes.getArtists()) {
+				root.addChild(new MusicDirectory.Entry(artist));
+			}
+			if (indexes.getEntries() != null) {
+				root.addChildren(indexes.getEntries());
+			}
+
+			boolean updated = downloadRecursively(syncedList, root, context, true);
+
+			ArrayList<String> oldSyncedList = SyncUtil.getSyncedLibrary(context, instance);
+			oldSyncedList.removeAll(syncedList);
+			for (String path : oldSyncedList) {
+				File saveFile = new File(path);
+				FileUtil.unpinSong(context, saveFile);
+			}
+
+			SyncUtil.setSyncedLibrary(syncedList, context, instance);
+			if (updated) {
+				Notifications.showSyncNotification(context, R.string.sync_new_library, null);
+			}
+		} catch (Exception e) {
+			Log.e(TAG, "Failed to sync library for " + Util.getServerName(context, instance), e);
+		}
+	}
+}

--- a/app/src/main/java/github/paroj/dsub2000/service/sync/LibrarySyncService.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/sync/LibrarySyncService.java
@@ -1,0 +1,41 @@
+/*
+ This file is part of Subsonic.
+
+ Subsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Subsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Subsonic.  If not, see <http://www.gnu.org/licenses/>.
+ */
+
+package github.paroj.dsub2000.service.sync;
+
+import android.app.Service;
+import android.content.Intent;
+import android.os.IBinder;
+
+public class LibrarySyncService extends Service {
+	private static LibrarySyncAdapter librarySyncAdapter;
+	private static final Object syncLock = new Object();
+
+	@Override
+	public void onCreate() {
+		synchronized (syncLock) {
+			if (librarySyncAdapter == null) {
+				librarySyncAdapter = new LibrarySyncAdapter(getApplicationContext(), true);
+			}
+		}
+	}
+
+	@Override
+	public IBinder onBind(Intent intent) {
+		return librarySyncAdapter.getSyncAdapterBinder();
+	}
+}

--- a/app/src/main/java/github/paroj/dsub2000/util/Constants.java
+++ b/app/src/main/java/github/paroj/dsub2000/util/Constants.java
@@ -139,6 +139,7 @@ public final class Constants {
 	public static final String PREFERENCES_KEY_SYNC_NOTIFICATION = "syncNotification";
 	public static final String PREFERENCES_KEY_SYNC_STARRED = "syncStarred";
 	public static final String PREFERENCES_KEY_SYNC_MOST_RECENT = "syncMostRecent";
+	public static final String PREFERENCES_KEY_SYNC_LIBRARY = "syncLibrary";
 	public static final String PREFERENCES_KEY_PAUSE_DISCONNECT = "pauseOnDisconnect";
 	public static final String PREFERENCES_KEY_HIDE_WIDGET = "hideWidget";
 	public static final String PREFERENCES_KEY_PODCASTS_ENABLED = "podcastsEnabled";
@@ -233,6 +234,7 @@ public final class Constants {
 	public static final String SYNC_ACCOUNT_PODCAST_AUTHORITY = BuildConfig.APPLICATION_ID + ".podcasts.provider";
 	public static final String SYNC_ACCOUNT_STARRED_AUTHORITY = BuildConfig.APPLICATION_ID + ".starred.provider";
 	public static final String SYNC_ACCOUNT_MOST_RECENT_AUTHORITY = BuildConfig.APPLICATION_ID + ".mostrecent.provider";
+	public static final String SYNC_ACCOUNT_LIBRARY_AUTHORITY = BuildConfig.APPLICATION_ID + ".library.provider";
 
 	public static final String TASKER_EXTRA_BUNDLE = "com.twofortyfouram.locale.intent.extra.BUNDLE";
 

--- a/app/src/main/java/github/paroj/dsub2000/util/SyncUtil.java
+++ b/app/src/main/java/github/paroj/dsub2000/util/SyncUtil.java
@@ -174,6 +174,21 @@ public final class SyncUtil {
 		return "sync-most_recent-" + (Util.getRestUrl(context, null, instance, false)).hashCode() + ".ser";
 	}
 
+	// Entire library
+	public static ArrayList<String> getSyncedLibrary(Context context, int instance) {
+		ArrayList<String> list = FileUtil.deserializeCompressed(context, getLibrarySyncFile(context, instance), ArrayList.class);
+		if(list == null) {
+			list = new ArrayList<String>();
+		}
+		return list;
+	}
+	public static void setSyncedLibrary(ArrayList<String> syncedList, Context context, int instance) {
+		FileUtil.serializeCompressed(context, syncedList, SyncUtil.getLibrarySyncFile(context, instance));
+	}
+	public static String getLibrarySyncFile(Context context, int instance) {
+		return "sync-library-" + (Util.getRestUrl(context, null, instance, false)).hashCode() + ".ser";
+	}
+
 	public static String joinNames(List<String> names) {
 		StringBuilder builder = new StringBuilder();
 		for (String val : names) {

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -236,6 +236,7 @@
 	<string name="sync.new_playlists">New songs in playlists</string>
 	<string name="sync.new_albums">New albums available</string>
 	<string name="sync.new_starred">New starred songs available</string>
+	<string name="sync.new_library">New library tracks cached</string>
     
 	<string name="starring_content_starred">Starred \"%s\"</string>
 	<string name="starring_content_unstarred">Unstarred \"%s\"</string>
@@ -444,6 +445,8 @@
 	<string name="settings.sync_most_recent_summary">Automatically cache newly added albums</string>
 	<string name="settings.sync_starred">Sync Starred</string>
 	<string name="settings.sync_starred_summary">Automatically cache songs, albums, and artists which are starred</string>
+	<string name="settings.sync_library">Cache Entire Library</string>
+	<string name="settings.sync_library_summary">Automatically cache every song in the library and keep the cache in sync with the server. Uses significant storage and bandwidth.</string>
 	<string name="settings.sync_notification">Show Sync Notification</string>
 	<string name="settings.sync_notification_summary">Show a notification after new media has been synced</string>
 	<string name="settings.menu_options.title">Optional Menu Options</string>

--- a/app/src/main/res/xml/library_syncadapter.xml
+++ b/app/src/main/res/xml/library_syncadapter.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<sync-adapter xmlns:android="http://schemas.android.com/apk/res/android"
+	android:contentAuthority="@string/provider.library"
+	android:accountType="@string/account_type.subsonic"
+	android:userVisible="true"
+	android:supportsUploading="false"
+	android:allowParallelSyncs="false"
+	android:isAlwaysSyncable="true"/>

--- a/app/src/main/res/xml/settings_sync.xml
+++ b/app/src/main/res/xml/settings_sync.xml
@@ -46,5 +46,11 @@
 			android:summary="@string/settings.sync_most_recent_summary"
 			android:key="syncMostRecent"
 			android:defaultValue="false"/>
+
+		<CheckBoxPreference
+			android:title="@string/settings.sync_library"
+			android:summary="@string/settings.sync_library_summary"
+			android:key="syncLibrary"
+			android:defaultValue="false"/>
 	</PreferenceCategory>
 </PreferenceScreen>


### PR DESCRIPTION
Adds a new opt-in "Cache Entire Library" sync that pins every track in the server's library for offline playback and keeps the local cache in sync as the library grows. Implemented as a new SyncAdapter alongside the existing Starred / MostRecent / Playlist / Podcast adapters, so it reuses the existing sync schedule, wifi/battery gating, and master "Sync Enabled" switch.

LibrarySyncAdapter walks the top-level index (honoring tag vs folder browsing through the inherited helper) and pins all songs via the existing SubsonicSyncAdapter.downloadRecursively() machinery. Songs removed server-side are unpinned via SyncUtil-tracked path lists, the same approach used by StarredSyncAdapter.

Wires up:
- LibrarySyncAdapter / LibrarySyncService / LibraryStubProvider
- library_syncadapter.xml + AndroidManifest service & provider entries
- provider.library resValue + SYNC_ACCOUNT_LIBRARY_AUTHORITY
- PREFERENCES_KEY_SYNC_LIBRARY constant + "Cache Entire Library" CheckBoxPreference in Settings → Sync (default off)
- ContentResolver.setSyncAutomatically + addPeriodicSync for the new authority in SubsonicFragmentActivity (matching the existing starred/mostrecent registration)
- SyncUtil.getSyncedLibrary / setSyncedLibrary helpers and R.string.sync_new_library notification text

Closes #73