### PR TITLE
Fix playback hang when many tracks are queued for download

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/service/DownloadService.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/DownloadService.java
@@ -2053,10 +2053,19 @@ public class DownloadService extends Service {
 				if (usbDevice != null) {
 					mediaPlayer.setPreferredDevice(usbDevice);
 					if (!downloadFile.isStream()) {
-						Integer rate = UsbDacHelper.readSampleRate(dataSource);
-						if (rate != null) {
-							Log.i(TAG, "USB DAC routing enabled; source sample rate " + rate + " Hz");
-						}
+						// Sample-rate probe is diagnostic only; run it off the
+						// service monitor so MediaExtractor I/O does not delay
+						// every play start.
+						final String probePath = dataSource;
+						new Thread(new Runnable() {
+							@Override
+							public void run() {
+								Integer rate = UsbDacHelper.readSampleRate(probePath);
+								if (rate != null) {
+									Log.i(TAG, "USB DAC routing enabled; source sample rate " + rate + " Hz");
+								}
+							}
+						}, "UsbDacSampleRateProbe").start();
 					}
 				}
 			}
@@ -2359,6 +2368,15 @@ public class DownloadService extends Service {
 		setNextPlayerState(IDLE);
 	}
 
+	private static boolean allLocallyAvailable(List<DownloadFile> files) {
+		for (DownloadFile d : files) {
+			if (!d.isCompleteFileAvailable()) {
+				return false;
+			}
+		}
+		return true;
+	}
+
 	public synchronized void checkDownloads() {
 		if (!Util.isExternalStoragePresent() || !lifecycleSupport.isExternalStorageAvailable()) {
 			return;
@@ -2374,18 +2392,20 @@ public class DownloadService extends Service {
 			checkArtistRadio();
 		}
 
-		// If all files are local (like when permanently caching an already cached file) do not check if device is offline
-		boolean skipNetworkCheck = true;
-		for (DownloadFile d: downloadList) {
-			skipNetworkCheck &= d.isCompleteFileAvailable();
-		}
-		for (DownloadFile d: backgroundDownloadList) {
-			skipNetworkCheck &= d.isCompleteFileAvailable();
-		}
-
-		if (!skipNetworkCheck && !Util.isAllowedToDownload(this)) {
-			Util.toast(this, R.string.select_album_no_network);
-			return;
+		// If the device is allowed to download we don't need to walk the
+		// queues at all. Only when downloads are forbidden do we need to
+		// check whether every queued file is already cached locally — and
+		// even then we can short-circuit on the first missing file. This
+		// matters when backgroundDownloadList holds 10k+ entries (issue
+		// #136): the previous unconditional full-list scan stat'd every
+		// file on every checkDownloads() call.
+		if (!Util.isAllowedToDownload(this)) {
+			boolean skipNetworkCheck = allLocallyAvailable(downloadList)
+					&& allLocallyAvailable(backgroundDownloadList);
+			if (!skipNetworkCheck) {
+				Util.toast(this, R.string.select_album_no_network);
+				return;
+			}
 		}
 
 		if (downloadList.isEmpty() && backgroundDownloadList.isEmpty()) {

--- a/app/src/main/java/github/paroj/dsub2000/util/BackgroundTask.java
+++ b/app/src/main/java/github/paroj/dsub2000/util/BackgroundTask.java
@@ -55,7 +55,11 @@ public abstract class BackgroundTask<T> implements ProgressListener {
 
 	private static final int DEFAULT_CONCURRENCY = 8;
 	private static final Collection<Thread> threads = Collections.synchronizedCollection(new ArrayList<Thread>());
-	protected static final BlockingQueue<BackgroundTask.Task> queue = new LinkedBlockingQueue<BackgroundTask.Task>(10);
+	// Unbounded queue: a bounded queue combined with queue.offer() in
+	// LoadingTask / SilentBackgroundTask silently dropped tasks when full,
+	// which caused the "Loading. Please Wait..." dialog to hang forever once
+	// the queue filled with pending DownloadTasks (issue #136).
+	protected static final BlockingQueue<BackgroundTask.Task> queue = new LinkedBlockingQueue<BackgroundTask.Task>();
 	private static Handler handler = null;
 	private static AtomicInteger currentlyRunning = new AtomicInteger(0);
 	static {


### PR DESCRIPTION
Pinning a large number of tracks (e.g. via the new entire-library sync) made any subsequent play action hang on the "Loading. Please Wait..." dialog forever, or take ~30 s with ~100 pinned tracks.

Two compounding causes:

- BackgroundTask used a single global LinkedBlockingQueue capped at 10, shared by LoadingTask, SilentBackgroundTask (incl. BufferTask), and every per-file DownloadTask. Both LoadingTask and SilentBackgroundTask enqueued with queue.offer() and ignored the return value, so once the queue filled with DownloadTasks the LoadingTask was silently dropped and its dialog never dismissed. Switch the queue to unbounded so enqueues never fail.

- DownloadService.checkDownloads() unconditionally walked both downloadList and backgroundDownloadList calling isCompleteFileAvailable() (two File.exists() syscalls per entry) with no short-circuit. BufferTask re-invokes checkDownloads() every second while waiting to buffer, so with 10k+ queued entries this stat-storm was held under the service monitor that play() needs. Skip the scan entirely when downloads are allowed, and short-circuit on the first missing file otherwise.

Also move the USB DAC sample-rate probe added in 1b21265b off the synchronized doPlay() path onto a one-shot worker thread; it is diagnostic logging only and should not delay play start.

Fixes #136