### PR TITLE
fix(DSubWidgetProvider.java): make hasInstances return false if AppWidgetManager is null

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/provider/DSubWidgetProvider.java
+++ b/app/src/main/java/github/paroj/dsub2000/provider/DSubWidgetProvider.java
@@ -141,6 +141,7 @@ public class DSubWidgetProvider extends AppWidgetProvider {
      */
     private boolean hasInstances(Context context) {
         AppWidgetManager manager = AppWidgetManager.getInstance(context);
+        if (manager == null) return false;
         int[] appWidgetIds = manager.getAppWidgetIds(new ComponentName(context, getClass()));
         return (appWidgetIds.length > 0);
     }


### PR DESCRIPTION
When this App is installed on WearOS, Playback does not work.
I quickly identified, that the AppWidgetManager is null. I guess this is due to WearOS not having Widgets.