### PR TITLE
Add synced lyrics via the OpenSubsonic songLyrics extension

### DIFF
--- a/app/src/main/java/github/paroj/dsub2000/adapter/LyricsAdapter.java
+++ b/app/src/main/java/github/paroj/dsub2000/adapter/LyricsAdapter.java
@@ -1,0 +1,132 @@
+/*
+ This file is part of Subsonic.
+
+ Subsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Subsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Subsonic.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package github.paroj.dsub2000.adapter;
+
+import android.graphics.Typeface;
+import android.view.LayoutInflater;
+import android.view.View;
+import android.view.ViewGroup;
+import android.widget.TextView;
+
+import androidx.recyclerview.widget.RecyclerView;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import github.paroj.dsub2000.R;
+import github.paroj.dsub2000.domain.LyricsLine;
+
+/**
+ * Displays lyrics one line per row.  When the lyrics are synced the line
+ * matching the current playback position is highlighted, and tapping a line
+ * seeks playback to it.
+ */
+public class LyricsAdapter extends RecyclerView.Adapter<LyricsAdapter.LineViewHolder> {
+	private static final float ACTIVE_ALPHA = 1.0f;
+	private static final float INACTIVE_ALPHA = 0.5f;
+
+	public interface OnLineClickListener {
+		void onLineClick(LyricsLine line);
+	}
+
+	private List<LyricsLine> lines;
+	private boolean synced;
+	private int activeLine = -1;
+	private OnLineClickListener onLineClickListener;
+
+	public LyricsAdapter(List<LyricsLine> lines, boolean synced) {
+		this.lines = lines;
+		this.synced = synced;
+	}
+
+	public void setOnLineClickListener(OnLineClickListener listener) {
+		this.onLineClickListener = listener;
+	}
+
+	/**
+	 * Swap in the lyrics of another song without recreating the adapter.
+	 */
+	public void setLyrics(List<LyricsLine> lines, boolean synced) {
+		this.lines = lines == null ? new ArrayList<LyricsLine>() : lines;
+		this.synced = synced;
+		this.activeLine = -1;
+		notifyDataSetChanged();
+	}
+
+	@Override
+	public LineViewHolder onCreateViewHolder(ViewGroup parent, int viewType) {
+		View view = LayoutInflater.from(parent.getContext()).inflate(R.layout.lyrics_line, parent, false);
+		return new LineViewHolder(view);
+	}
+
+	@Override
+	public void onBindViewHolder(LineViewHolder holder, int position) {
+		final LyricsLine line = lines.get(position);
+		holder.textView.setText(line.getValue());
+
+		// Unsynced lyrics have no current line, so everything stays fully visible.
+		boolean highlight = synced && position == activeLine;
+		holder.textView.setAlpha((!synced || highlight) ? ACTIVE_ALPHA : INACTIVE_ALPHA);
+		holder.textView.setTypeface(null, highlight ? Typeface.BOLD : Typeface.NORMAL);
+
+		boolean seekable = synced && line.getStart() != null && onLineClickListener != null;
+		holder.itemView.setClickable(seekable);
+		if(seekable) {
+			holder.itemView.setOnClickListener(new View.OnClickListener() {
+				@Override
+				public void onClick(View v) {
+					onLineClickListener.onLineClick(line);
+				}
+			});
+		} else {
+			holder.itemView.setOnClickListener(null);
+		}
+	}
+
+	@Override
+	public int getItemCount() {
+		return lines.size();
+	}
+
+	public int getActiveLine() {
+		return activeLine;
+	}
+
+	public void setActiveLine(int line) {
+		if(line == activeLine) {
+			return;
+		}
+
+		int previous = activeLine;
+		activeLine = line;
+		if(previous >= 0 && previous < lines.size()) {
+			notifyItemChanged(previous);
+		}
+		if(activeLine >= 0 && activeLine < lines.size()) {
+			notifyItemChanged(activeLine);
+		}
+	}
+
+	public static class LineViewHolder extends RecyclerView.ViewHolder {
+		private final TextView textView;
+
+		public LineViewHolder(View itemView) {
+			super(itemView);
+			this.textView = (TextView) itemView.findViewById(R.id.lyrics_line);
+		}
+	}
+}

--- a/app/src/main/java/github/paroj/dsub2000/domain/LyricsLine.java
+++ b/app/src/main/java/github/paroj/dsub2000/domain/LyricsLine.java
@@ -1,0 +1,49 @@
+/*
+ This file is part of Subsonic.
+
+ Subsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Subsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Subsonic.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package github.paroj.dsub2000.domain;
+
+import java.io.Serializable;
+
+/**
+ * A single line of song lyrics, as returned by the OpenSubsonic
+ * getLyricsBySongId endpoint.
+ */
+public class LyricsLine implements Serializable {
+
+	private Long start;
+	private String value;
+
+	/**
+	 * Start time of this line in milliseconds from the beginning of the song,
+	 * or null when the lyrics are not synced.
+	 */
+	public Long getStart() {
+		return start;
+	}
+
+	public void setStart(Long start) {
+		this.start = start;
+	}
+
+	public String getValue() {
+		return value;
+	}
+
+	public void setValue(String value) {
+		this.value = value;
+	}
+}

--- a/app/src/main/java/github/paroj/dsub2000/domain/StructuredLyrics.java
+++ b/app/src/main/java/github/paroj/dsub2000/domain/StructuredLyrics.java
@@ -1,0 +1,97 @@
+/*
+ This file is part of Subsonic.
+
+ Subsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Subsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Subsonic.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package github.paroj.dsub2000.domain;
+
+import java.io.Serializable;
+import java.util.ArrayList;
+import java.util.List;
+
+/**
+ * One set of song lyrics as returned by the OpenSubsonic getLyricsBySongId
+ * endpoint.  A song may have several sets, for instance a synced and an
+ * unsynced one, or one per language.
+ */
+public class StructuredLyrics implements Serializable {
+
+	private String displayArtist;
+	private String displayTitle;
+	private String lang;
+	private Long offset;
+	private boolean synced;
+	private List<LyricsLine> lines = new ArrayList<LyricsLine>();
+
+	public String getDisplayArtist() {
+		return displayArtist;
+	}
+
+	public void setDisplayArtist(String displayArtist) {
+		this.displayArtist = displayArtist;
+	}
+
+	public String getDisplayTitle() {
+		return displayTitle;
+	}
+
+	public void setDisplayTitle(String displayTitle) {
+		this.displayTitle = displayTitle;
+	}
+
+	/**
+	 * ISO 639 language code of these lyrics, "xxx" when unknown.
+	 */
+	public String getLang() {
+		return lang;
+	}
+
+	public void setLang(String lang) {
+		this.lang = lang;
+	}
+
+	/**
+	 * Offset in milliseconds to add to every line's start time.
+	 */
+	public Long getOffset() {
+		return offset;
+	}
+
+	public void setOffset(Long offset) {
+		this.offset = offset;
+	}
+
+	/**
+	 * Whether the lines carry timestamps.
+	 */
+	public boolean isSynced() {
+		return synced;
+	}
+
+	public void setSynced(boolean synced) {
+		this.synced = synced;
+	}
+
+	public List<LyricsLine> getLines() {
+		return lines;
+	}
+
+	public void setLines(List<LyricsLine> lines) {
+		this.lines = lines;
+	}
+
+	public void addLine(LyricsLine line) {
+		this.lines.add(line);
+	}
+}

--- a/app/src/main/java/github/paroj/dsub2000/fragments/LyricsFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/LyricsFragment.java
@@ -306,6 +306,15 @@ public final class LyricsFragment extends SubsonicFragment implements DownloadSe
 
 	@Override
 	public void onStateUpdate(DownloadFile downloadFile, PlayerState playerState) {
+		// Collapse the interpolation into the stored position before the playing
+		// flag changes. Otherwise time spent paused would count into the estimate,
+		// and the first real position after resuming would look like a seek.
+		if(hasPosition) {
+			long now = SystemClock.elapsedRealtime();
+			lastKnownPosition = estimatePosition(now);
+			lastKnownAt = now;
+		}
+
 		playing = playerState == PlayerState.STARTED;
 	}
 

--- a/app/src/main/java/github/paroj/dsub2000/fragments/LyricsFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/LyricsFragment.java
@@ -326,16 +326,15 @@ public final class LyricsFragment extends SubsonicFragment implements DownloadSe
 	private void load(final String id, final String artist, final String title) {
 		final int generation = ++loadGeneration;
 
-		BackgroundTask<Void> task = new TabBackgroundTask<Void>(this) {
+		BackgroundTask<LoadResult> task = new TabBackgroundTask<LoadResult>(this) {
 			@Override
-			protected Void doInBackground() throws Throwable {
+			protected LoadResult doInBackground() throws Throwable {
 				MusicService musicService = MusicServiceFactory.getMusicService(context);
-				ArrayList<StructuredLyrics> versions = null;
-				Lyrics plain = null;
+				LoadResult result = new LoadResult();
 
 				if(id != null) {
 					try {
-						versions = usableVersions(musicService.getLyricsBySongId(id, context, this));
+						result.versions = usableVersions(musicService.getLyricsBySongId(id, context, this));
 					} catch(Exception e) {
 						// Server does not support the songLyrics extension, or the
 						// lookup failed. Fall back to the legacy endpoint below.
@@ -343,27 +342,27 @@ public final class LyricsFragment extends SubsonicFragment implements DownloadSe
 					}
 				}
 
-				int selected = selectVersion(versions);
-				if(selected < 0) {
-					plain = musicService.getLyrics(artist, title, context, this);
+				result.selected = selectVersion(result.versions);
+				if(result.selected < 0) {
+					result.plain = musicService.getLyrics(artist, title, context, this);
 				}
 
-				if(generation == loadGeneration) {
-					lyricsVersions = versions;
-					selectedVersion = selected;
-					structuredLyrics = versionAt(selected);
-					lyrics = plain;
-				}
-
-				return null;
+				return result;
 			}
 
 			@Override
-			protected void done(Void result) {
-				// Skipping tracks quickly can finish loads out of order.
+			protected void done(LoadResult result) {
+				// Skipping tracks quickly can finish loads out of order. Loads run
+				// concurrently, so the fields are only assigned here on the main
+				// thread, where the generation check and the assignment are atomic.
 				if(generation != loadGeneration) {
 					return;
 				}
+
+				lyricsVersions = result.versions;
+				selectedVersion = result.selected;
+				structuredLyrics = versionAt(result.selected);
+				lyrics = result.plain;
 
 				setLyrics();
 				updateActiveLine(true);
@@ -373,6 +372,12 @@ public final class LyricsFragment extends SubsonicFragment implements DownloadSe
 			}
 		};
 		task.execute();
+	}
+
+	private static class LoadResult {
+		private ArrayList<StructuredLyrics> versions;
+		private int selected = -1;
+		private Lyrics plain;
 	}
 
 	private ArrayList<StructuredLyrics> usableVersions(List<StructuredLyrics> candidates) {

--- a/app/src/main/java/github/paroj/dsub2000/fragments/LyricsFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/LyricsFragment.java
@@ -675,7 +675,9 @@ public final class LyricsFragment extends SubsonicFragment implements DownloadSe
 		}
 		adapter.setActiveLine(active);
 
-		if(!autoScroll || active < 0 || !canCenter(active)) {
+		// Never scroll while the user's gesture is still in progress; when it
+		// ends, the scroll session decides whether following is still on.
+		if(!autoScroll || userScrolling || active < 0 || !canCenter(active)) {
 			return;
 		}
 
@@ -764,6 +766,11 @@ public final class LyricsFragment extends SubsonicFragment implements DownloadSe
 
 		int active = adapter.getActiveLine();
 		if(active < 0) {
+			// Nothing is highlighted yet, so there is no line to measure the
+			// scroll against; treat any deliberate scroll as parking the list.
+			// Otherwise reading ahead during an intro would be yanked back to
+			// the first line the moment it lights up.
+			autoScroll = false;
 			return;
 		}
 

--- a/app/src/main/java/github/paroj/dsub2000/fragments/LyricsFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/LyricsFragment.java
@@ -512,9 +512,13 @@ public final class LyricsFragment extends SubsonicFragment implements DownloadSe
 						seekToLine(line);
 					}
 				});
-				lineList.setAdapter(adapter);
 			} else {
 				adapter.setLyrics(structuredLyrics.getLines(), structuredLyrics.isSynced());
+			}
+			// The view can be recreated while the fragment instance and its adapter
+			// survive, so a non-null adapter is not necessarily attached to this list.
+			if(lineList.getAdapter() != adapter) {
+				lineList.setAdapter(adapter);
 			}
 
 			// These are different lyrics, so the old scroll position is meaningless.

--- a/app/src/main/java/github/paroj/dsub2000/fragments/LyricsFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/LyricsFragment.java
@@ -145,6 +145,7 @@ public final class LyricsFragment extends SubsonicFragment implements DownloadSe
 
 		refreshLayout = (SwipeRefreshLayout) rootView.findViewById(R.id.refresh_layout);
 		refreshLayout.setOnRefreshListener(this);
+		setupScrollList(lineList);
 
 		layoutManager = getLinearLayoutManager();
 		lineList.setLayoutManager(layoutManager);
@@ -560,6 +561,13 @@ public final class LyricsFragment extends SubsonicFragment implements DownloadSe
 			textView.setText(null);
 			lineList.setVisibility(View.GONE);
 			scrollView.setVisibility(View.VISIBLE);
+		}
+
+		// setupScrollList only re-enables pull to refresh from the line list's
+		// scroll events; when the plain text view is showing instead, the gate
+		// must not stay closed at wherever the list was last left.
+		if(scrollView.getVisibility() == View.VISIBLE && context.isTouchscreen()) {
+			refreshLayout.setEnabled(true);
 		}
 	}
 

--- a/app/src/main/java/github/paroj/dsub2000/fragments/LyricsFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/LyricsFragment.java
@@ -43,6 +43,7 @@ import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
+import java.util.MissingResourceException;
 
 import github.paroj.dsub2000.R;
 import github.paroj.dsub2000.adapter.LyricsAdapter;
@@ -461,13 +462,20 @@ public final class LyricsFragment extends SubsonicFragment implements DownloadSe
 			return false;
 		}
 
-		String device = Locale.getDefault().getLanguage();
-		if(device == null || device.length() == 0) {
-			return false;
+		// The server may use either ISO 639-1 ("en") or 639-2/3 ("eng"), so
+		// compare against both forms exactly; prefix matching would make a
+		// device set to "es" claim Estonian ("est").
+		Locale device = Locale.getDefault();
+		if(lang.equalsIgnoreCase(device.getLanguage())) {
+			return true;
 		}
 
-		// The server may use either ISO 639-1 ("en") or 639-2/3 ("eng").
-		return lang.toLowerCase(Locale.US).startsWith(device.toLowerCase(Locale.US));
+		try {
+			return lang.equalsIgnoreCase(device.getISO3Language());
+		} catch(MissingResourceException e) {
+			// The device language has no three letter form to compare against.
+			return false;
+		}
 	}
 
 	private boolean hasKnownLanguage(String lang) {

--- a/app/src/main/java/github/paroj/dsub2000/fragments/LyricsFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/LyricsFragment.java
@@ -58,6 +58,7 @@ import github.paroj.dsub2000.service.MusicServiceFactory;
 import github.paroj.dsub2000.util.BackgroundTask;
 import github.paroj.dsub2000.util.Constants;
 import github.paroj.dsub2000.util.TabBackgroundTask;
+import github.paroj.dsub2000.util.Util;
 
 /**
  * Displays song lyrics.
@@ -259,6 +260,12 @@ public final class LyricsFragment extends SubsonicFragment implements DownloadSe
 	@Override
 	public void onSongChanged(DownloadFile currentPlaying, int currentPlayingIndex, boolean shouldFastForward) {
 		if(currentPlaying == null) {
+			return;
+		}
+
+		// Lyrics can be opened for any song, not just the one playing, so whether
+		// they stay anchored to that song or move with the queue is a preference.
+		if(!Util.getPreferences(context).getBoolean(Constants.PREFERENCES_KEY_LYRICS_FOLLOW_QUEUE, true)) {
 			return;
 		}
 

--- a/app/src/main/java/github/paroj/dsub2000/fragments/LyricsFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/LyricsFragment.java
@@ -19,13 +19,40 @@
 
 package github.paroj.dsub2000.fragments;
 
+import android.content.DialogInterface;
 import android.os.Bundle;
+import android.os.Handler;
+import android.os.SystemClock;
+import android.util.Log;
 import android.view.LayoutInflater;
+import android.view.Menu;
+import android.view.MenuInflater;
+import android.view.MenuItem;
 import android.view.View;
 import android.view.ViewGroup;
+import android.view.WindowManager;
+import android.widget.ScrollView;
 import android.widget.TextView;
+
+import androidx.appcompat.app.AlertDialog;
+import androidx.recyclerview.widget.LinearLayoutManager;
+import androidx.recyclerview.widget.LinearSmoothScroller;
+import androidx.recyclerview.widget.RecyclerView;
+import androidx.swiperefreshlayout.widget.SwipeRefreshLayout;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Locale;
+
 import github.paroj.dsub2000.R;
+import github.paroj.dsub2000.adapter.LyricsAdapter;
 import github.paroj.dsub2000.domain.Lyrics;
+import github.paroj.dsub2000.domain.LyricsLine;
+import github.paroj.dsub2000.domain.MusicDirectory;
+import github.paroj.dsub2000.domain.PlayerState;
+import github.paroj.dsub2000.domain.StructuredLyrics;
+import github.paroj.dsub2000.service.DownloadFile;
+import github.paroj.dsub2000.service.DownloadService;
 import github.paroj.dsub2000.service.MusicService;
 import github.paroj.dsub2000.service.MusicServiceFactory;
 import github.paroj.dsub2000.util.BackgroundTask;
@@ -35,14 +62,54 @@ import github.paroj.dsub2000.util.TabBackgroundTask;
 /**
  * Displays song lyrics.
  *
+ * Prefers the OpenSubsonic getLyricsBySongId endpoint, which is keyed by song
+ * id and can return timestamped lines.  Synced lyrics follow playback: the
+ * current line is highlighted, the list scrolls to keep it in view, and tapping
+ * a line seeks to it.  Servers without that extension fall back to the legacy
+ * artist/title based getLyrics endpoint.
+ *
  * @author Sindre Mehus
  */
-public final class LyricsFragment extends SubsonicFragment {
+public final class LyricsFragment extends SubsonicFragment implements DownloadService.OnSongChangedListener {
+	private static final String TAG = LyricsFragment.class.getSimpleName();
+	private static final String STATE_VERSIONS = "lyrics.versions";
+	private static final String STATE_SELECTED_VERSION = "lyrics.selectedVersion";
+
+	// The service only refreshes its cached position once a second, so the
+	// position is interpolated between updates to keep highlighting tight.
+	private static final long INTERPOLATE_INTERVAL = 200L;
+	// A jump larger than this between the expected and reported position is a seek.
+	private static final long SEEK_THRESHOLD = 2000L;
+	// Beyond this many lines, jump rather than animate.
+	private static final int SNAP_DISTANCE = 4;
+
 	private TextView artistView;
 	private TextView titleView;
 	private TextView textView;
+	private ScrollView scrollView;
+	private RecyclerView lineList;
+	private LinearLayoutManager layoutManager;
+	private LyricsAdapter adapter;
 
 	private Lyrics lyrics;
+	private ArrayList<StructuredLyrics> lyricsVersions;
+	private int selectedVersion = -1;
+	private StructuredLyrics structuredLyrics;
+
+	private String songId;
+	private String songArtist;
+	private String songTitle;
+	private int loadGeneration = 0;
+
+	private boolean autoScroll = true;
+	private boolean userScrolling = false;
+	private boolean playing = false;
+	private boolean hasPosition = false;
+	private long lastKnownPosition = 0L;
+	private long lastKnownAt = 0L;
+
+	private final Handler handler = new Handler();
+	private Runnable interpolateRunnable;
 
 	@Override
 	public void onCreate(Bundle bundle) {
@@ -50,6 +117,9 @@ public final class LyricsFragment extends SubsonicFragment {
 
 		if(bundle != null) {
 			lyrics = (Lyrics) bundle.getSerializable(Constants.FRAGMENT_LIST);
+			lyricsVersions = (ArrayList<StructuredLyrics>) bundle.getSerializable(STATE_VERSIONS);
+			selectedVersion = bundle.getInt(STATE_SELECTED_VERSION, -1);
+			structuredLyrics = versionAt(selectedVersion);
 		}
 	}
 
@@ -57,6 +127,8 @@ public final class LyricsFragment extends SubsonicFragment {
 	public void onSaveInstanceState(Bundle outState) {
 		super.onSaveInstanceState(outState);
 		outState.putSerializable(Constants.FRAGMENT_LIST, lyrics);
+		outState.putSerializable(STATE_VERSIONS, lyricsVersions);
+		outState.putInt(STATE_SELECTED_VERSION, selectedVersion);
 	}
 
 	@Override
@@ -67,9 +139,48 @@ public final class LyricsFragment extends SubsonicFragment {
 		artistView = (TextView) rootView.findViewById(R.id.lyrics_artist);
 		titleView = (TextView) rootView.findViewById(R.id.lyrics_title);
 		textView = (TextView) rootView.findViewById(R.id.lyrics_text);
+		scrollView = (ScrollView) rootView.findViewById(R.id.lyrics_scroll);
+		lineList = (RecyclerView) rootView.findViewById(R.id.lyrics_list);
 
-		if(lyrics == null) {
-			load();
+		refreshLayout = (SwipeRefreshLayout) rootView.findViewById(R.id.refresh_layout);
+		refreshLayout.setOnRefreshListener(this);
+
+		layoutManager = getLinearLayoutManager();
+		lineList.setLayoutManager(layoutManager);
+		// The default change animation cross-fades item alpha, which is also what
+		// marks the current line. Without this, rows that scroll off during a
+		// highlight change keep the animator's alpha and stay lit.
+		lineList.setItemAnimator(null);
+		lineList.addOnScrollListener(new RecyclerView.OnScrollListener() {
+			@Override
+			public void onScrollStateChanged(RecyclerView recyclerView, int newState) {
+				if(newState == RecyclerView.SCROLL_STATE_DRAGGING) {
+					// A drag opens a user scroll session; a fling keeps it open
+					// through SETTLING until the list comes to rest.
+					userScrolling = true;
+				} else if(newState == RecyclerView.SCROLL_STATE_IDLE && userScrolling) {
+					updateAutoScroll();
+					userScrolling = false;
+				}
+			}
+
+			@Override
+			public void onScrolled(RecyclerView recyclerView, int dx, int dy) {
+				// Only react to scrolling the user drove. Programmatic scrolling
+				// moves towards a line that is off screen by definition, and
+				// would otherwise immediately switch following off.
+				if(userScrolling) {
+					updateAutoScroll();
+				}
+			}
+		});
+
+		songId = getArguments().getString(Constants.INTENT_EXTRA_NAME_ID);
+		songArtist = getArguments().getString(Constants.INTENT_EXTRA_NAME_ARTIST);
+		songTitle = getArguments().getString(Constants.INTENT_EXTRA_NAME_TITLE);
+
+		if(lyrics == null && structuredLyrics == null) {
+			load(songId, songArtist, songTitle);
 		} else {
 			setLyrics();
 		}
@@ -77,32 +188,569 @@ public final class LyricsFragment extends SubsonicFragment {
 		return rootView;
 	}
 
-	private void load() {
-		BackgroundTask<Lyrics> task = new TabBackgroundTask<Lyrics>(this) {
+	@Override
+	public void onStart() {
+		super.onStart();
+
+		context.runWhenServiceAvailable(new Runnable() {
 			@Override
-			protected Lyrics doInBackground() throws Throwable {
-				String artist = getArguments().getString(Constants.INTENT_EXTRA_NAME_ARTIST);
-				String title = getArguments().getString(Constants.INTENT_EXTRA_NAME_TITLE);
+			public void run() {
+				DownloadService downloadService = getDownloadService();
+				if(downloadService == null) {
+					return;
+				}
+
+				downloadService.addOnSongChangedListener(LyricsFragment.this, true);
+
+				// Reading along is hard if the screen turns off. Only honours the
+				// existing preference; NowPlayingFragment owns clearing the flag.
+				if(downloadService.getKeepScreenOn()) {
+					context.getWindow().addFlags(WindowManager.LayoutParams.FLAG_KEEP_SCREEN_ON);
+				}
+			}
+		});
+
+		startInterpolating();
+	}
+
+	@Override
+	public void onStop() {
+		super.onStop();
+
+		DownloadService downloadService = getDownloadService();
+		if(downloadService != null) {
+			downloadService.removeOnSongChangeListener(this);
+		}
+
+		stopInterpolating();
+	}
+
+	@Override
+	public void onCreateOptionsMenu(Menu menu, MenuInflater menuInflater) {
+		// Only worth offering when the server actually returned alternatives.
+		if(lyricsVersions != null && lyricsVersions.size() > 1) {
+			menuInflater.inflate(R.menu.lyrics, menu);
+		}
+	}
+
+	@Override
+	public boolean onOptionsItemSelected(MenuItem item) {
+		if(item.getItemId() == R.id.menu_lyrics_version) {
+			showVersionDialog();
+			return true;
+		}
+
+		return super.onOptionsItemSelected(item);
+	}
+
+	@Override
+	protected void refresh(boolean refresh) {
+		lyrics = null;
+		lyricsVersions = null;
+		selectedVersion = -1;
+		structuredLyrics = null;
+		autoScroll = true;
+
+		load(songId, songArtist, songTitle);
+	}
+
+	// OnSongChangedListener
+
+	@Override
+	public void onSongChanged(DownloadFile currentPlaying, int currentPlayingIndex, boolean shouldFastForward) {
+		if(currentPlaying == null) {
+			return;
+		}
+
+		MusicDirectory.Entry song = currentPlaying.getSong();
+		if(song == null || song.getId() == null || song.getId().equals(songId)) {
+			return;
+		}
+
+		songId = song.getId();
+		songArtist = song.getArtist();
+		songTitle = song.getTitle();
+
+		lyrics = null;
+		lyricsVersions = null;
+		selectedVersion = -1;
+		structuredLyrics = null;
+		autoScroll = true;
+		hasPosition = false;
+		lastKnownPosition = 0L;
+
+		load(songId, songArtist, songTitle);
+	}
+
+	@Override
+	public void onSongsChanged(List<DownloadFile> songs, DownloadFile currentPlaying, int currentPlayingIndex, boolean shouldFastForward) {
+
+	}
+
+	@Override
+	public void onSongProgress(DownloadFile currentPlaying, int millisPlayed, Integer duration, boolean isSeekable) {
+		long now = SystemClock.elapsedRealtime();
+		boolean seeked = hasPosition && Math.abs(millisPlayed - estimatePosition(now)) > SEEK_THRESHOLD;
+
+		lastKnownPosition = millisPlayed;
+		lastKnownAt = now;
+		hasPosition = true;
+
+		if(seeked) {
+			// Jumping deliberately is a request to follow along again.
+			autoScroll = true;
+		}
+
+		updateActiveLine(seeked);
+	}
+
+	@Override
+	public void onStateUpdate(DownloadFile downloadFile, PlayerState playerState) {
+		playing = playerState == PlayerState.STARTED;
+	}
+
+	@Override
+	public void onMetadataUpdate(MusicDirectory.Entry entry, int fieldChange) {
+
+	}
+
+	private void load(final String id, final String artist, final String title) {
+		final int generation = ++loadGeneration;
+
+		BackgroundTask<Void> task = new TabBackgroundTask<Void>(this) {
+			@Override
+			protected Void doInBackground() throws Throwable {
 				MusicService musicService = MusicServiceFactory.getMusicService(context);
-				return musicService.getLyrics(artist, title, context, this);
+				ArrayList<StructuredLyrics> versions = null;
+				Lyrics plain = null;
+
+				if(id != null) {
+					try {
+						versions = usableVersions(musicService.getLyricsBySongId(id, context, this));
+					} catch(Exception e) {
+						// Server does not support the songLyrics extension, or the
+						// lookup failed. Fall back to the legacy endpoint below.
+						Log.d(TAG, "getLyricsBySongId failed, falling back to getLyrics", e);
+					}
+				}
+
+				int selected = selectVersion(versions);
+				if(selected < 0) {
+					plain = musicService.getLyrics(artist, title, context, this);
+				}
+
+				if(generation == loadGeneration) {
+					lyricsVersions = versions;
+					selectedVersion = selected;
+					structuredLyrics = versionAt(selected);
+					lyrics = plain;
+				}
+
+				return null;
 			}
 
 			@Override
-			protected void done(Lyrics result) {
-				lyrics = result;
+			protected void done(Void result) {
+				// Skipping tracks quickly can finish loads out of order.
+				if(generation != loadGeneration) {
+					return;
+				}
+
 				setLyrics();
+				updateActiveLine(true);
+
+				// The version picker only exists when there is something to pick.
+				context.supportInvalidateOptionsMenu();
 			}
 		};
 		task.execute();
 	}
 
+	private ArrayList<StructuredLyrics> usableVersions(List<StructuredLyrics> candidates) {
+		if(candidates == null) {
+			return null;
+		}
+
+		ArrayList<StructuredLyrics> usable = new ArrayList<StructuredLyrics>();
+		for(StructuredLyrics candidate: candidates) {
+			if(!candidate.getLines().isEmpty()) {
+				usable.add(candidate);
+			}
+		}
+
+		return usable.isEmpty() ? null : usable;
+	}
+
+	/**
+	 * A song can carry several sets of lyrics. Prefer synced ones, and within
+	 * that prefer the device language when the server tells us the language.
+	 */
+	private int selectVersion(List<StructuredLyrics> candidates) {
+		if(candidates == null) {
+			return -1;
+		}
+
+		int syncedInLanguage = -1;
+		int syncedAny = -1;
+		int plainInLanguage = -1;
+		int plainAny = -1;
+
+		for(int i = 0; i < candidates.size(); i++) {
+			StructuredLyrics candidate = candidates.get(i);
+			boolean matchesLanguage = matchesDeviceLanguage(candidate.getLang());
+
+			if(candidate.isSynced()) {
+				if(matchesLanguage && syncedInLanguage < 0) {
+					syncedInLanguage = i;
+				}
+				if(syncedAny < 0) {
+					syncedAny = i;
+				}
+			} else {
+				if(matchesLanguage && plainInLanguage < 0) {
+					plainInLanguage = i;
+				}
+				if(plainAny < 0) {
+					plainAny = i;
+				}
+			}
+		}
+
+		if(syncedInLanguage >= 0) {
+			return syncedInLanguage;
+		} else if(syncedAny >= 0) {
+			return syncedAny;
+		} else if(plainInLanguage >= 0) {
+			return plainInLanguage;
+		} else {
+			return plainAny;
+		}
+	}
+
+	private StructuredLyrics versionAt(int index) {
+		if(lyricsVersions == null || index < 0 || index >= lyricsVersions.size()) {
+			return null;
+		}
+		return lyricsVersions.get(index);
+	}
+
+	private boolean matchesDeviceLanguage(String lang) {
+		if(!hasKnownLanguage(lang)) {
+			return false;
+		}
+
+		String device = Locale.getDefault().getLanguage();
+		if(device == null || device.length() == 0) {
+			return false;
+		}
+
+		// The server may use either ISO 639-1 ("en") or 639-2/3 ("eng").
+		return lang.toLowerCase(Locale.US).startsWith(device.toLowerCase(Locale.US));
+	}
+
+	private boolean hasKnownLanguage(String lang) {
+		// "xxx" and "und" both mean the server does not know the language.
+		return lang != null && !"xxx".equalsIgnoreCase(lang) && !"und".equalsIgnoreCase(lang);
+	}
+
+	private void showVersionDialog() {
+		if(lyricsVersions == null || lyricsVersions.size() < 2) {
+			return;
+		}
+
+		CharSequence[] labels = new CharSequence[lyricsVersions.size()];
+		for(int i = 0; i < lyricsVersions.size(); i++) {
+			labels[i] = versionLabel(lyricsVersions.get(i));
+		}
+
+		new AlertDialog.Builder(context)
+			.setTitle(R.string.lyrics_select_version)
+			.setSingleChoiceItems(labels, selectedVersion, new DialogInterface.OnClickListener() {
+				@Override
+				public void onClick(DialogInterface dialog, int which) {
+					dialog.dismiss();
+					if(which == selectedVersion) {
+						return;
+					}
+
+					selectedVersion = which;
+					structuredLyrics = versionAt(which);
+					autoScroll = true;
+					setLyrics();
+					updateActiveLine(true);
+				}
+			})
+			.show();
+	}
+
+	private String versionLabel(StructuredLyrics version) {
+		String lang = version.getLang();
+		String name;
+
+		if(!hasKnownLanguage(lang)) {
+			name = getString(R.string.lyrics_unknown_language);
+		} else {
+			// Three letter codes often have no display name; fall back to the code.
+			String display = new Locale(lang).getDisplayLanguage();
+			name = (display == null || display.length() == 0 || display.equalsIgnoreCase(lang)) ? lang : display;
+		}
+
+		String kind = getString(version.isSynced() ? R.string.lyrics_synced : R.string.lyrics_unsynced);
+		return getString(R.string.lyrics_version_format, name, kind);
+	}
+
 	private void setLyrics() {
-		if (lyrics != null && lyrics.getArtist() != null) {
+		if(structuredLyrics != null) {
+			artistView.setText(firstNonEmpty(structuredLyrics.getDisplayArtist(), songArtist));
+			titleView.setText(firstNonEmpty(structuredLyrics.getDisplayTitle(), songTitle));
+
+			if(adapter == null) {
+				adapter = new LyricsAdapter(structuredLyrics.getLines(), structuredLyrics.isSynced());
+				adapter.setOnLineClickListener(new LyricsAdapter.OnLineClickListener() {
+					@Override
+					public void onLineClick(LyricsLine line) {
+						seekToLine(line);
+					}
+				});
+				lineList.setAdapter(adapter);
+			} else {
+				adapter.setLyrics(structuredLyrics.getLines(), structuredLyrics.isSynced());
+			}
+
+			// These are different lyrics, so the old scroll position is meaningless.
+			// Without this the next song opens wherever the last one was left.
+			layoutManager.scrollToPositionWithOffset(0, 0);
+
+			scrollView.setVisibility(View.GONE);
+			lineList.setVisibility(View.VISIBLE);
+		} else if(lyrics != null && lyrics.getArtist() != null) {
 			artistView.setText(lyrics.getArtist());
 			titleView.setText(lyrics.getTitle());
 			textView.setText(lyrics.getText());
+			lineList.setVisibility(View.GONE);
+			scrollView.setVisibility(View.VISIBLE);
 		} else {
 			artistView.setText(R.string.lyrics_nomatch);
+			titleView.setText(songTitle);
+			textView.setText(null);
+			lineList.setVisibility(View.GONE);
+			scrollView.setVisibility(View.VISIBLE);
+		}
+	}
+
+	private String firstNonEmpty(String first, String second) {
+		if(first != null && first.length() > 0) {
+			return first;
+		}
+		return second;
+	}
+
+	private void seekToLine(LyricsLine line) {
+		DownloadService downloadService = getDownloadService();
+		if(downloadService == null || line.getStart() == null || !isShowingCurrentSong()) {
+			return;
+		}
+
+		downloadService.seekTo((int) Math.max(0L, line.getStart() - lyricsOffset()));
+		autoScroll = true;
+	}
+
+	/**
+	 * Lyrics can be opened for any song in the queue, not just the one playing.
+	 * Playback position only describes the song actually playing, so following
+	 * and seeking are limited to that case.
+	 */
+	private boolean isShowingCurrentSong() {
+		DownloadService downloadService = getDownloadService();
+		if(downloadService == null || songId == null) {
+			return false;
+		}
+
+		DownloadFile currentPlaying = downloadService.getCurrentPlaying();
+		return currentPlaying != null && currentPlaying.getSong() != null
+				&& songId.equals(currentPlaying.getSong().getId());
+	}
+
+	private long lyricsOffset() {
+		if(structuredLyrics == null || structuredLyrics.getOffset() == null) {
+			return 0L;
+		}
+		return structuredLyrics.getOffset();
+	}
+
+	private long estimatePosition(long now) {
+		if(!playing) {
+			return lastKnownPosition;
+		}
+		return lastKnownPosition + (now - lastKnownAt);
+	}
+
+	private void startInterpolating() {
+		if(interpolateRunnable != null) {
+			return;
+		}
+
+		interpolateRunnable = new Runnable() {
+			@Override
+			public void run() {
+				updateActiveLine(false);
+				handler.postDelayed(this, INTERPOLATE_INTERVAL);
+			}
+		};
+		handler.postDelayed(interpolateRunnable, INTERPOLATE_INTERVAL);
+	}
+
+	private void stopInterpolating() {
+		if(interpolateRunnable != null) {
+			handler.removeCallbacks(interpolateRunnable);
+			interpolateRunnable = null;
+		}
+	}
+
+	private void updateActiveLine(boolean snap) {
+		if(adapter == null || lineList == null || structuredLyrics == null || !structuredLyrics.isSynced()) {
+			return;
+		}
+
+		if(!isShowingCurrentSong()) {
+			// Showing another song's lyrics: no line is current.
+			adapter.setActiveLine(-1);
+			return;
+		}
+
+		long position = estimatePosition(SystemClock.elapsedRealtime());
+		long offset = lyricsOffset();
+
+		List<LyricsLine> lines = structuredLyrics.getLines();
+		int active = -1;
+		for(int i = 0; i < lines.size(); i++) {
+			Long start = lines.get(i).getStart();
+			if(start == null) {
+				continue;
+			}
+
+			if(position >= (start - offset)) {
+				active = i;
+			} else {
+				break;
+			}
+		}
+
+		int previous = adapter.getActiveLine();
+		if(active == previous) {
+			return;
+		}
+		adapter.setActiveLine(active);
+
+		if(!autoScroll || active < 0 || !canCenter(active)) {
+			return;
+		}
+
+		if(snap || previous < 0 || Math.abs(active - previous) > SNAP_DISTANCE) {
+			layoutManager.scrollToPositionWithOffset(active, centerOffset());
+		} else {
+			smoothScrollToCenter(active);
+		}
+	}
+
+	/**
+	 * Whether the line can actually be moved to the middle.
+	 *
+	 * Near the start of the lyrics the list is already scrolled to the top, so
+	 * centring would mean scrolling past the beginning; the same applies at the
+	 * end. Asking for that scroll does not move anything, it just triggers the
+	 * overscroll bounce, so the early and late lines are left where they are and
+	 * scrolling begins once the current line actually reaches the middle.
+	 */
+	private boolean canCenter(int position) {
+		View child = layoutManager.findViewByPosition(position);
+		if(child == null) {
+			// Off screen, so scrolling is both possible and needed.
+			return true;
+		}
+
+		int listCenter = lineList.getHeight() / 2;
+		int childCenter = (child.getTop() + child.getBottom()) / 2;
+		int delta = childCenter - listCenter;
+
+		if(delta > 0) {
+			return lineList.canScrollVertically(1);
+		} else if(delta < 0) {
+			return lineList.canScrollVertically(-1);
+		}
+
+		return false;
+	}
+
+	/**
+	 * Offset that leaves the current line in the middle of the list.
+	 */
+	private int centerOffset() {
+		int listHeight = lineList.getHeight();
+		if(listHeight <= 0) {
+			return 0;
+		}
+
+		int rowHeight = 0;
+		View child = layoutManager.findViewByPosition(adapter.getActiveLine());
+		if(child != null) {
+			rowHeight = child.getHeight();
+		} else if(lineList.getChildCount() > 0) {
+			rowHeight = lineList.getChildAt(0).getHeight();
+		}
+
+		return Math.max(0, (listHeight - rowHeight) / 2);
+	}
+
+	/**
+	 * smoothScrollToPosition only scrolls far enough to bring a line into view,
+	 * which leaves it pinned to the bottom edge with nothing visible ahead of it.
+	 * Centring instead keeps the upcoming lines readable.
+	 */
+	private void smoothScrollToCenter(int position) {
+		LinearSmoothScroller scroller = new LinearSmoothScroller(context) {
+			@Override
+			public int calculateDtToFit(int viewStart, int viewEnd, int boxStart, int boxEnd, int snapPreference) {
+				return (boxStart + (boxEnd - boxStart) / 2) - (viewStart + (viewEnd - viewStart) / 2);
+			}
+		};
+		scroller.setTargetPosition(position);
+		layoutManager.startSmoothScroll(scroller);
+	}
+
+	/**
+	 * Following stops once the user scrolls the current line out of view, and
+	 * resumes when they bring it back.  The thresholds differ on purpose:
+	 * leaving needs the line fully gone, returning needs it fully visible, so
+	 * that a line resting on the edge does not toggle repeatedly.
+	 */
+	private void updateAutoScroll() {
+		if(adapter == null || layoutManager == null) {
+			return;
+		}
+
+		int active = adapter.getActiveLine();
+		if(active < 0) {
+			return;
+		}
+
+		int first = layoutManager.findFirstVisibleItemPosition();
+		int last = layoutManager.findLastVisibleItemPosition();
+		if(first == RecyclerView.NO_POSITION || last == RecyclerView.NO_POSITION) {
+			return;
+		}
+
+		if(active < first || active > last) {
+			autoScroll = false;
+		} else if(!autoScroll) {
+			int firstComplete = layoutManager.findFirstCompletelyVisibleItemPosition();
+			int lastComplete = layoutManager.findLastCompletelyVisibleItemPosition();
+			if(firstComplete != RecyclerView.NO_POSITION && lastComplete != RecyclerView.NO_POSITION
+					&& active >= firstComplete && active <= lastComplete) {
+				// Resume quietly: the next line change scrolls, so the list does
+				// not jump underneath the finger that just brought it back.
+				autoScroll = true;
+			}
 		}
 	}
 }

--- a/app/src/main/java/github/paroj/dsub2000/fragments/LyricsFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/LyricsFragment.java
@@ -105,6 +105,7 @@ public final class LyricsFragment extends SubsonicFragment implements DownloadSe
 
 	private boolean autoScroll = true;
 	private boolean userScrolling = false;
+	private boolean started = false;
 	private boolean playing = false;
 	private boolean hasPosition = false;
 	private long lastKnownPosition = 0L;
@@ -194,10 +195,17 @@ public final class LyricsFragment extends SubsonicFragment implements DownloadSe
 	@Override
 	public void onStart() {
 		super.onStart();
+		started = true;
 
 		context.runWhenServiceAvailable(new Runnable() {
 			@Override
 			public void run() {
+				// The service can come up only after the fragment has stopped
+				// again; a listener registered then would never be removed.
+				if(!started) {
+					return;
+				}
+
 				DownloadService downloadService = getDownloadService();
 				if(downloadService == null) {
 					return;
@@ -219,6 +227,7 @@ public final class LyricsFragment extends SubsonicFragment implements DownloadSe
 	@Override
 	public void onStop() {
 		super.onStop();
+		started = false;
 
 		DownloadService downloadService = getDownloadService();
 		if(downloadService != null) {

--- a/app/src/main/java/github/paroj/dsub2000/fragments/NowPlayingFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/NowPlayingFragment.java
@@ -695,16 +695,6 @@ public class NowPlayingFragment extends SubsonicFragment implements OnGestureLis
 				intent.setFlags(Intent.FLAG_ACTIVITY_CLEAR_TOP);
 				Util.startActivityWithoutTransition(context, intent);
 				return true;
-			case R.id.menu_lyrics: {
-				SubsonicFragment fragment = new LyricsFragment();
-				Bundle args = new Bundle();
-				args.putString(Constants.INTENT_EXTRA_NAME_ARTIST, song.getSong().getArtist());
-				args.putString(Constants.INTENT_EXTRA_NAME_TITLE, song.getSong().getTitle());
-				fragment.setArguments(args);
-
-				replaceFragment(fragment);
-				return true;
-			}
 			case R.id.menu_remove_all:
 				Util.confirmDialog(context, R.string.download_menu_remove_all, "", new DialogInterface.OnClickListener() {
 					@Override

--- a/app/src/main/java/github/paroj/dsub2000/fragments/SubsonicFragment.java
+++ b/app/src/main/java/github/paroj/dsub2000/fragments/SubsonicFragment.java
@@ -487,6 +487,9 @@ public class SubsonicFragment extends Fragment implements SwipeRefreshLayout.OnR
 			case R.id.menu_rate:
 				UpdateHelper.setRating(context, entry);
 				break;
+			case R.id.menu_lyrics:
+				showLyrics(entry);
+				break;
 			default:
 				return false;
 		}
@@ -1282,6 +1285,21 @@ public class SubsonicFragment extends Fragment implements SwipeRefreshLayout.OnR
             }
         });
 		dialog.show();
+	}
+
+	public void showLyrics(final Entry song) {
+		if(song == null) {
+			return;
+		}
+
+		SubsonicFragment fragment = new LyricsFragment();
+		Bundle args = new Bundle();
+		args.putString(Constants.INTENT_EXTRA_NAME_ID, song.getId());
+		args.putString(Constants.INTENT_EXTRA_NAME_ARTIST, song.getArtist());
+		args.putString(Constants.INTENT_EXTRA_NAME_TITLE, song.getTitle());
+		fragment.setArguments(args);
+
+		replaceFragment(fragment);
 	}
 
 	public void displaySongInfo(final Entry song) {

--- a/app/src/main/java/github/paroj/dsub2000/service/CachedMusicService.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/CachedMusicService.java
@@ -43,6 +43,7 @@ import github.paroj.dsub2000.domain.PlayerQueue;
 import github.paroj.dsub2000.domain.PodcastEpisode;
 import github.paroj.dsub2000.domain.RemoteStatus;
 import github.paroj.dsub2000.domain.Lyrics;
+import github.paroj.dsub2000.domain.StructuredLyrics;
 import github.paroj.dsub2000.domain.MusicDirectory;
 import github.paroj.dsub2000.domain.MusicFolder;
 import github.paroj.dsub2000.domain.Playlist;
@@ -518,6 +519,11 @@ public class CachedMusicService implements MusicService {
     @Override
     public Lyrics getLyrics(String artist, String title, Context context, ProgressListener progressListener) throws Exception {
         return musicService.getLyrics(artist, title, context, progressListener);
+    }
+
+    @Override
+    public List<StructuredLyrics> getLyricsBySongId(String id, Context context, ProgressListener progressListener) throws Exception {
+        return musicService.getLyricsBySongId(id, context, progressListener);
     }
 
     @Override

--- a/app/src/main/java/github/paroj/dsub2000/service/MusicService.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/MusicService.java
@@ -40,6 +40,7 @@ import github.paroj.dsub2000.domain.PodcastChannel;
 import github.paroj.dsub2000.domain.SearchCritera;
 import github.paroj.dsub2000.domain.SearchResult;
 import github.paroj.dsub2000.domain.Share;
+import github.paroj.dsub2000.domain.StructuredLyrics;
 import github.paroj.dsub2000.domain.User;
 import github.paroj.dsub2000.util.SilentBackgroundTask;
 import github.paroj.dsub2000.util.ProgressListener;
@@ -86,6 +87,14 @@ public interface MusicService {
 	void updatePlaylist(String id, String name, String comment, boolean pub, Context context, ProgressListener progressListener) throws Exception;
 
     Lyrics getLyrics(String artist, String title, Context context, ProgressListener progressListener) throws Exception;
+
+    /**
+     * Lyrics for a song from the OpenSubsonic getLyricsBySongId endpoint, which
+     * unlike getLyrics is keyed by song id and can return timestamped lines.
+     * Servers without the songLyrics extension will fail this call, so callers
+     * are expected to fall back to {@link #getLyrics}.
+     */
+    List<StructuredLyrics> getLyricsBySongId(String id, Context context, ProgressListener progressListener) throws Exception;
 
     void scrobble(String id, boolean submission, Context context, ProgressListener progressListener) throws Exception;
 

--- a/app/src/main/java/github/paroj/dsub2000/service/OfflineMusicService.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/OfflineMusicService.java
@@ -46,6 +46,7 @@ import github.paroj.dsub2000.domain.PlayerQueue;
 import github.paroj.dsub2000.domain.PodcastEpisode;
 import github.paroj.dsub2000.domain.RemoteStatus;
 import github.paroj.dsub2000.domain.Lyrics;
+import github.paroj.dsub2000.domain.StructuredLyrics;
 import github.paroj.dsub2000.domain.MusicDirectory;
 import github.paroj.dsub2000.domain.MusicFolder;
 import github.paroj.dsub2000.domain.Playlist;
@@ -530,6 +531,11 @@ public class OfflineMusicService implements MusicService {
 
     @Override
     public Lyrics getLyrics(String artist, String title, Context context, ProgressListener progressListener) throws Exception {
+		throw new OfflineException(ERRORMSG);
+    }
+
+    @Override
+    public List<StructuredLyrics> getLyricsBySongId(String id, Context context, ProgressListener progressListener) throws Exception {
 		throw new OfflineException(ERRORMSG);
     }
 

--- a/app/src/main/java/github/paroj/dsub2000/service/RESTMusicService.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/RESTMusicService.java
@@ -55,6 +55,7 @@ import github.paroj.dsub2000.service.parser.IndexesParser;
 import github.paroj.dsub2000.service.parser.InternetRadioStationParser;
 import github.paroj.dsub2000.service.parser.JukeboxStatusParser;
 import github.paroj.dsub2000.service.parser.LicenseParser;
+import github.paroj.dsub2000.service.parser.LyricsListParser;
 import github.paroj.dsub2000.service.parser.LyricsParser;
 import github.paroj.dsub2000.service.parser.MusicDirectoryParser;
 import github.paroj.dsub2000.service.parser.MusicFoldersParser;
@@ -522,6 +523,16 @@ public class RESTMusicService implements MusicService {
         Reader reader = getReader(context, progressListener, "getLyrics", Arrays.asList("artist", "title"), Arrays.<Object>asList(artist, title));
         try {
             return new LyricsParser(context, getInstance(context)).parse(reader, progressListener);
+        } finally {
+            Util.close(reader);
+        }
+    }
+
+    @Override
+    public List<StructuredLyrics> getLyricsBySongId(String id, Context context, ProgressListener progressListener) throws Exception {
+        Reader reader = getReader(context, progressListener, "getLyricsBySongId", "id", id);
+        try {
+            return new LyricsListParser(context, getInstance(context)).parse(reader, progressListener);
         } finally {
             Util.close(reader);
         }

--- a/app/src/main/java/github/paroj/dsub2000/service/parser/LyricsListParser.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/parser/LyricsListParser.java
@@ -1,0 +1,118 @@
+/*
+ This file is part of Subsonic.
+
+ Subsonic is free software: you can redistribute it and/or modify
+ it under the terms of the GNU General Public License as published by
+ the Free Software Foundation, either version 3 of the License, or
+ (at your option) any later version.
+
+ Subsonic is distributed in the hope that it will be useful,
+ but WITHOUT ANY WARRANTY; without even the implied warranty of
+ MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ GNU General Public License for more details.
+
+ You should have received a copy of the GNU General Public License
+ along with Subsonic.  If not, see <http://www.gnu.org/licenses/>.
+ */
+package github.paroj.dsub2000.service.parser;
+
+import android.content.Context;
+
+import org.xmlpull.v1.XmlPullParser;
+
+import java.io.Reader;
+import java.util.ArrayList;
+import java.util.List;
+
+import github.paroj.dsub2000.domain.LyricsLine;
+import github.paroj.dsub2000.domain.StructuredLyrics;
+import github.paroj.dsub2000.util.ProgressListener;
+
+/**
+ * Parses the lyricsList response of the OpenSubsonic getLyricsBySongId
+ * endpoint:
+ *
+ * <pre>
+ * &lt;lyricsList&gt;
+ *   &lt;structuredLyrics displayArtist=".." displayTitle=".." lang="eng" offset="0" synced="true"&gt;
+ *     &lt;line start="18800"&gt;We're no strangers to love&lt;/line&gt;
+ *   &lt;/structuredLyrics&gt;
+ * &lt;/lyricsList&gt;
+ * </pre>
+ *
+ * Elements are collected on START_TAG and flushed when the following element
+ * (or the end of the document) is reached, so that END_TAG never has to be
+ * inspected -- attribute access is only valid on START_TAG.
+ */
+public class LyricsListParser extends AbstractParser {
+
+	public LyricsListParser(Context context, int instance) {
+		super(context, instance);
+	}
+
+	public List<StructuredLyrics> parse(Reader reader, ProgressListener progressListener) throws Exception {
+		init(reader);
+
+		List<StructuredLyrics> lyricsList = new ArrayList<StructuredLyrics>();
+		StructuredLyrics current = null;
+		LyricsLine currentLine = null;
+
+		int eventType;
+		do {
+			eventType = nextParseEvent();
+			if (eventType == XmlPullParser.START_TAG) {
+				String name = getElementName();
+				if ("structuredLyrics".equals(name)) {
+					current = addLine(current, currentLine);
+					currentLine = null;
+					current = addLyrics(lyricsList, current);
+
+					current = new StructuredLyrics();
+					current.setDisplayArtist(get("displayArtist"));
+					current.setDisplayTitle(get("displayTitle"));
+					current.setLang(get("lang"));
+					current.setOffset(getLong("offset"));
+					current.setSynced(getBoolean("synced"));
+				} else if ("line".equals(name)) {
+					current = addLine(current, currentLine);
+
+					currentLine = new LyricsLine();
+					currentLine.setStart(getLong("start"));
+				} else if ("error".equals(name)) {
+					handleError();
+				}
+			} else if (eventType == XmlPullParser.TEXT) {
+				// The first text node after a <line> is its content.  Whitespace
+				// between elements can also land here for empty lines, which
+				// trims away to the empty string.
+				if (currentLine != null && currentLine.getValue() == null) {
+					String text = getText();
+					currentLine.setValue(text == null ? "" : text.trim());
+				}
+			}
+		} while (eventType != XmlPullParser.END_DOCUMENT);
+
+		current = addLine(current, currentLine);
+		addLyrics(lyricsList, current);
+
+		validate();
+		return lyricsList;
+	}
+
+	private StructuredLyrics addLine(StructuredLyrics current, LyricsLine line) {
+		if (current != null && line != null) {
+			if (line.getValue() == null) {
+				line.setValue("");
+			}
+			current.addLine(line);
+		}
+		return current;
+	}
+
+	private StructuredLyrics addLyrics(List<StructuredLyrics> lyricsList, StructuredLyrics current) {
+		if (current != null) {
+			lyricsList.add(current);
+		}
+		return null;
+	}
+}

--- a/app/src/main/java/github/paroj/dsub2000/service/parser/LyricsListParser.java
+++ b/app/src/main/java/github/paroj/dsub2000/service/parser/LyricsListParser.java
@@ -17,6 +17,7 @@
 package github.paroj.dsub2000.service.parser;
 
 import android.content.Context;
+import android.util.Log;
 
 import org.xmlpull.v1.XmlPullParser;
 
@@ -45,6 +46,7 @@ import github.paroj.dsub2000.util.ProgressListener;
  * inspected -- attribute access is only valid on START_TAG.
  */
 public class LyricsListParser extends AbstractParser {
+	private static final String TAG = LyricsListParser.class.getSimpleName();
 
 	public LyricsListParser(Context context, int instance) {
 		super(context, instance);
@@ -71,13 +73,13 @@ public class LyricsListParser extends AbstractParser {
 					current.setDisplayArtist(get("displayArtist"));
 					current.setDisplayTitle(get("displayTitle"));
 					current.setLang(get("lang"));
-					current.setOffset(getLong("offset"));
+					current.setOffset(getLongSafe("offset"));
 					current.setSynced(getBoolean("synced"));
 				} else if ("line".equals(name)) {
 					current = addLine(current, currentLine);
 
 					currentLine = new LyricsLine();
-					currentLine.setStart(getLong("start"));
+					currentLine.setStart(getLongSafe("start"));
 				} else if ("error".equals(name)) {
 					handleError();
 				}
@@ -97,6 +99,19 @@ public class LyricsListParser extends AbstractParser {
 
 		validate();
 		return lyricsList;
+	}
+
+	/**
+	 * Like getLong, but a malformed value reads as absent instead of failing the
+	 * parse: one bad timestamp should not cost the whole set of lyrics.
+	 */
+	private Long getLongSafe(String name) {
+		try {
+			return getLong(name);
+		} catch(NumberFormatException e) {
+			Log.w(TAG, "Ignoring malformed " + name + " attribute", e);
+			return null;
+		}
 	}
 
 	private StructuredLyrics addLine(StructuredLyrics current, LyricsLine line) {

--- a/app/src/main/java/github/paroj/dsub2000/util/Constants.java
+++ b/app/src/main/java/github/paroj/dsub2000/util/Constants.java
@@ -119,6 +119,7 @@ public final class Constants {
 	public static final String PREFERENCES_KEY_SHUFFLE_END_YEAR = "endYear";
 	public static final String PREFERENCES_KEY_SHUFFLE_GENRE = "genre";
 	public static final String PREFERENCES_KEY_KEEP_SCREEN_ON = "keepScreenOn";
+	public static final String PREFERENCES_KEY_LYRICS_FOLLOW_QUEUE = "lyricsFollowQueue";
 	public static final String PREFERENCES_EQUALIZER_ON = "equalizerOn";
 	public static final String PREFERENCES_EQUALIZER_SETTINGS = "equalizerSettings";
 	public static final String PREFERENCES_KEY_PERSISTENT_NOTIFICATION = "persistentNotification";

--- a/app/src/main/res/layout/lyrics.xml
+++ b/app/src/main/res/layout/lyrics.xml
@@ -1,54 +1,65 @@
 <?xml version="1.0" encoding="utf-8"?>
-<LinearLayout xmlns:android="http://schemas.android.com/apk/res/android"
-	android:orientation="vertical"
+<androidx.swiperefreshlayout.widget.SwipeRefreshLayout xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@+id/refresh_layout"
 	android:layout_width="fill_parent"
 	android:layout_height="fill_parent">
 
-	<include layout="@layout/tab_progress"/>
-
-	<ScrollView
+	<LinearLayout
+		android:orientation="vertical"
 		android:layout_width="fill_parent"
-		android:layout_height="0dip"
-		android:layout_weight="1.0">
+		android:layout_height="fill_parent">
 
-		<LinearLayout
-			android:orientation="vertical"
+		<include layout="@layout/tab_progress"/>
+
+		<TextView
+			android:id="@+id/lyrics_artist"
+			android:textAppearance="?android:attr/textAppearanceMedium"
+			android:gravity="center_horizontal"
 			android:layout_width="fill_parent"
-			android:layout_height="fill_parent">
+			android:layout_height="wrap_content"
+			android:paddingLeft="10dip"
+			android:paddingRight="10dip"
+			android:paddingTop="10dip"
+			android:paddingBottom="4dip"
+			android:textColor="?android:textColorPrimary"/>
 
-			<TextView
-				android:id="@+id/lyrics_artist"
-				android:textAppearance="?android:attr/textAppearanceMedium"
-				android:gravity="center_horizontal"
+		<TextView
+			android:id="@+id/lyrics_title"
+			android:textAppearance="?android:attr/textAppearanceSmall"
+			android:gravity="center_horizontal"
+			android:layout_width="fill_parent"
+			android:layout_height="wrap_content"
+			android:paddingLeft="10dip"
+			android:paddingRight="10dip"
+			android:paddingBottom="12dip"
+			android:textColor="?android:textColorPrimary"/>
+
+		<FrameLayout
+			android:layout_width="fill_parent"
+			android:layout_height="0dip"
+			android:layout_weight="1.0">
+
+			<ScrollView
+				android:id="@+id/lyrics_scroll"
 				android:layout_width="fill_parent"
-				android:layout_height="wrap_content"
-				android:paddingLeft="10dip"
-				android:paddingRight="10dip"
-				android:paddingTop="10dip"
-				android:paddingBottom="4dip"
-				android:textColor="?android:textColorPrimary"/>
+				android:layout_height="fill_parent">
 
-			<TextView
-				android:id="@+id/lyrics_title"
-				android:textAppearance="?android:attr/textAppearanceSmall"
-				android:gravity="center_horizontal"
+				<TextView
+					android:id="@+id/lyrics_text"
+					android:textAppearance="?android:attr/textAppearanceSmall"
+					android:gravity="center_horizontal"
+					android:layout_width="fill_parent"
+					android:layout_height="wrap_content"
+					android:paddingLeft="10dip"
+					android:paddingRight="10dip"
+					android:textColor="?android:textColorSecondary"/>
+			</ScrollView>
+
+			<androidx.recyclerview.widget.RecyclerView
+				android:id="@+id/lyrics_list"
 				android:layout_width="fill_parent"
-				android:layout_height="wrap_content"
-				android:paddingLeft="10dip"
-				android:paddingRight="10dip"
-				android:paddingBottom="12dip"
-				android:textColor="?android:textColorPrimary"/>
-
-			<TextView
-				android:id="@+id/lyrics_text"
-				android:textAppearance="?android:attr/textAppearanceSmall"
-				android:gravity="center_horizontal"
-				android:layout_width="fill_parent"
-				android:layout_height="wrap_content"
-				android:paddingLeft="10dip"
-				android:paddingRight="10dip"
-				android:textColor="?android:textColorSecondary"/>
-		</LinearLayout>
-	</ScrollView>
-</LinearLayout>
-
+				android:layout_height="fill_parent"
+				android:visibility="gone"/>
+		</FrameLayout>
+	</LinearLayout>
+</androidx.swiperefreshlayout.widget.SwipeRefreshLayout>

--- a/app/src/main/res/layout/lyrics_line.xml
+++ b/app/src/main/res/layout/lyrics_line.xml
@@ -1,0 +1,13 @@
+<?xml version="1.0" encoding="utf-8"?>
+<TextView xmlns:android="http://schemas.android.com/apk/res/android"
+	android:id="@+id/lyrics_line"
+	android:layout_width="fill_parent"
+	android:layout_height="wrap_content"
+	android:textAppearance="?android:attr/textAppearanceMedium"
+	android:background="?android:attr/selectableItemBackground"
+	android:gravity="center_horizontal"
+	android:paddingLeft="16dip"
+	android:paddingRight="16dip"
+	android:paddingTop="6dip"
+	android:paddingBottom="6dip"
+	android:textColor="?android:textColorPrimary"/>

--- a/app/src/main/res/menu/lyrics.xml
+++ b/app/src/main/res/menu/lyrics.xml
@@ -1,0 +1,8 @@
+<?xml version="1.0" encoding="utf-8"?>
+<menu xmlns:android="http://schemas.android.com/apk/res/android"
+	  xmlns:compat="http://schemas.android.com/apk/res-auto">
+	<item
+		android:id="@+id/menu_lyrics_version"
+		android:title="@string/lyrics.select_version"
+		compat:showAsAction="never"/>
+</menu>

--- a/app/src/main/res/menu/select_song_context.xml
+++ b/app/src/main/res/menu/select_song_context.xml
@@ -15,6 +15,10 @@
 			android:title="@string/menu.show_artist"/>
 	</group>
 
+	<item
+		android:id="@+id/menu_lyrics"
+		android:title="@string/download.menu_lyrics"/>
+
 	<group android:id="@+id/hide_play_now">
 		<item
 			android:id="@+id/song_menu_play_now"

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -271,6 +271,11 @@
 	<string name="song_details.downloading">Downloading</string>
 
     <string name="lyrics.nomatch">No lyrics found</string>
+    <string name="lyrics.select_version">Lyrics version</string>
+    <string name="lyrics.version_format">%1$s (%2$s)</string>
+    <string name="lyrics.synced">synced</string>
+    <string name="lyrics.unsynced">plain</string>
+    <string name="lyrics.unknown_language">Unknown language</string>
 
     <string name="error.label">Error</string>
 

--- a/app/src/main/res/values/strings.xml
+++ b/app/src/main/res/values/strings.xml
@@ -720,6 +720,8 @@
 	<string name="settings.tap_cover_for_playlist_summary">Open the current playlist when clicking on the album art</string>
 	<string name="settings.combine_thumbs_up_down">Combine rating buttons</string>
 	<string name="settings.combine_thumbs_up_down_summary">Merge the thumbs up and thumbs down buttons into one single button that opens a rating dialog</string>
+	<string name="settings.lyrics_follow_queue">Lyrics follow the queue</string>
+	<string name="settings.lyrics_follow_queue_summary">When the track changes, switch to the new song\'s lyrics instead of keeping the ones that are open</string>
 
     <string name="color_picker.title">Select a Color</string>
     <string name="color_picker.hue">Hue</string>

--- a/app/src/main/res/xml/settings_playback.xml
+++ b/app/src/main/res/xml/settings_playback.xml
@@ -87,6 +87,12 @@
             android:key="combineThumbsUpDown"
             android:defaultValue="false"/>
 
+        <CheckBoxPreference
+            android:title="@string/settings.lyrics_follow_queue"
+            android:summary="@string/settings.lyrics_follow_queue_summary"
+            android:key="lyricsFollowQueue"
+            android:defaultValue="true"/>
+
 	</PreferenceCategory>
 
 	<PreferenceCategory


### PR DESCRIPTION
## What this adds

Lyrics were previously fetched only through the legacy `getLyrics` endpoint — keyed by artist + title, returning one block of plain text. This adds support for the OpenSubsonic [`songLyrics` extension](https://opensubsonic.netlify.app/docs/extensions/songlyrics/) (`getLyricsBySongId`), which is keyed by song id and can return timestamped lines plus multiple lyric sets per song.

When synced lyrics are available:

- the current line is highlighted and kept centred while the song plays
- tapping a line seeks to it
- scrolling the current line out of view suspends following; bringing it back (or seeking) resumes it, so the list never fights the user
- seeking jumps rather than animating through the intervening lines; pull-to-refresh refetches
- when the server returns several lyric sets (languages, synced vs plain), an options-menu picker switches between them, preferring synced sets in the device language

Lyrics are also reachable from any song's context menu (album, playlist, search results, the queue) — this addresses the pain in #151 (reaching a track's lyrics is slow), though via the context menu rather than the album-art tap suggested there, so I've left the issue for your judgement rather than auto-closing it.

Because playback can move on while viewing another song's lyrics, a new playback preference — **Lyrics follow the queue** (default on) — chooses whether open lyrics switch with the queue on track change or stay anchored to the song they were opened for.

Servers without the extension are unaffected: `getLyricsBySongId` is attempted first and any failure falls back to the legacy `getLyrics` path, which is left untouched. Offline behaviour is unchanged (embedded lyrics offline is #150 and out of scope here).

## Design notes

- Position tracking piggybacks on `DownloadService.onSongProgress` (the existing 1 Hz push) and interpolates between updates with `SystemClock.elapsedRealtime()` — no additional polling of the service. The interpolation clock is frozen across pause/resume so a pause never reads as a seek.
- The parser accumulates on `START_TAG` and flushes forward, like every other parser in the codebase (attribute access is only valid on start tags). A malformed `start`/`offset` degrades that one value instead of failing the parse.
- `CachedMusicService` passes the new call through, matching the existing `getLyrics`; caching would be a follow-up.
- The line list's item animator is disabled: the default change animation cross-fades item alpha, which is also what marks the current line.

## Commit series

The branch is deliberately a series: the base feature, then three bug fixes found in an adversarial review pass with on-device testing (adapter reattachment when the fragment view is recreated, interpolation across pause/resume, thread-confinement of load results), then the queue-follow preference and smaller hardening (scroll-gesture guards, exact ISO 639 language matching, lenient timestamp parsing, listener lifecycle). The pieces are separate to make review easier, not to preserve history — **squash-merging into `edge` is the intent**.

## Testing

Tested against **Navidrome 0.63.2** (Subsonic API 1.16.1, `openSubsonic=true`) with the **nd-lyrics plugin** providing lyrics (priority chain of `.lrc`/`.ttml`/etc. files, embedded tags, then on-demand fetch — the first `getLyricsBySongId` for a song can return an empty `lyricsList` while the plugin fetches, a later request succeeds, which pull-to-refresh handles). Device: OnePlus, Android 16, arm64.

Two complementary passes:

- **Scripted adb-driven testing (AI-assisted):** open-from-list vs open-from-queue, track changes in both preference modes, rotation and state restore, pause/resume around the seek-detection threshold, scroll disengage/re-engage, tap-to-seek, pull-to-refresh.
- **Manual testing (me):** normal day-to-day listening with the usage patterns of someone who actually reads lyrics — browsing, queueing albums, skipping, scrolling ahead, switching songs mid-read.

Not exercised end-to-end, in the interest of honesty:

- the version picker against a server that returns more than one lyric set (my server returns one; the selection logic is code-reviewed only)
- the legacy fallback against a live server without the extension (it triggers on any failure, but I had no pre-OpenSubsonic server to point at)
- offline (deliberately unchanged)

If it helps review: I can set up a demo user on my server so you can test against a live synced-lyrics setup in a minute, without replicating the server + plugin configuration — just say the word.

## Authorship

The design decisions are mine; the code is entirely AI-written — the base feature by Claude Opus, the review pass and all subsequent fixes by Claude Fable (each commit carries its co-author trailer). Happy to iterate on anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
